### PR TITLE
fix(token-holders): re-offer Refresh when a holder update is stuck

### DIFF
--- a/src/views/TokenHolders/index.tsx
+++ b/src/views/TokenHolders/index.tsx
@@ -150,6 +150,12 @@ mutation updateTokenHolders($address: String!){
 
 const ITEMS_PER_PAGE = 50;
 
+// If the reported progress hasn't advanced for this long, the backend update
+// task has almost certainly died (e.g. the worker was killed mid-run, which
+// leaves the progress fields frozen). Treat it as stuck and re-offer Refresh so
+// the user isn't stranded staring at a progress bar that will never move.
+const STUCK_AFTER_MS = 2 * 60 * 1000;
+
 interface ProgressBarProps {
     queryProgress: number | null;
     saveProgress: number | null;
@@ -267,6 +273,14 @@ const TokenHolders = () => {
     const [queryProgress, setQueryProgress] = useState<number | null>(null)
     const [saveProgress, setSaveProgress] = useState<number | null>(null)
 
+    // True once an in-progress update has stopped advancing for STUCK_AFTER_MS —
+    // i.e. its worker died and the progress fields are frozen.
+    const [progressStalled, setProgressStalled] = useState(false)
+    // Last seen progress signature + when it last changed, to detect the stall.
+    // Seeded with at:0 (no Date.now() during render); the effect below resets it
+    // before the timestamp is ever used in a comparison.
+    const progressStallRef = useRef<{ sig: string; at: number }>({ sig: "", at: 0 })
+
     const startIndex = useMemo(() => {
         return (currentPage - 1) * ITEMS_PER_PAGE;
     }, [currentPage]);
@@ -363,6 +377,19 @@ const TokenHolders = () => {
 
         setQueryProgress(minQueryProgress);
         setSaveProgress(minSaveProgress);
+
+        // Stall detection: this effect re-runs on every poll (every 5s). If the
+        // progress signature is unchanged for STUCK_AFTER_MS, the update task is
+        // dead and we surface Refresh again (see below). Any change — including
+        // progress clearing to null on completion — resets the timer.
+        const sig = `${minQueryProgress}|${minSaveProgress}`;
+        const now = Date.now();
+        if ((minQueryProgress === null && minSaveProgress === null) || sig !== progressStallRef.current.sig) {
+            progressStallRef.current = { sig, at: now };
+            setProgressStalled(false);
+        } else if (now - progressStallRef.current.at > STUCK_AFTER_MS) {
+            setProgressStalled(true);
+        }
 
         if (!minQueryProgress && !minSaveProgress) void refetch();
     }, [progressData, refetch]);
@@ -803,14 +830,19 @@ const TokenHolders = () => {
                                     Unknown last updated <GrStatusUnknown className="text-base" />
                                 </span>
                             }
-                            {!queryProgress && !saveProgress &&
+                            {(!queryProgress && !saveProgress || progressStalled) &&
                                 <button onClick={handleUpdateTokenHolders} className={BTN}>
                                     Refresh
                                 </button>
                             }
+                            {progressStalled &&
+                                <span className="flex items-center gap-1 text-amber-400">
+                                    <MdWarning className="text-base" /> Update looks stuck — try Refresh
+                                </span>
+                            }
                         </div>
                     }
-                    {(queryProgress || saveProgress) &&
+                    {(queryProgress || saveProgress) && !progressStalled &&
                         <ProgressBar queryProgress={queryProgress} saveProgress={saveProgress} />
                     }
                     {error && <div className="mt-3 rounded-lg bg-red-500/10 px-3 py-2 font-sans text-sm text-red-400">


### PR DESCRIPTION
## Problem

On `/token-holders`, the backend nulls `holders_query_progress` / `holders_save_progress` only on **clean completion** (or a caught error). If the update worker is **hard-killed** mid-run — e.g. OOM on a very large token like qunt (~419k holders) — those fields stay frozen.

The UI hid the **Refresh** button whenever progress was non-null and showed a perpetual progress bar, so the user was stranded watching a bar that would never move, with no way to retrigger the update.

## Fix

Detect the stall. The progress query polls every 5s, so if the reported progress signature is unchanged for `STUCK_AFTER_MS` (2 min), treat the update as dead:
- hide the frozen progress bar,
- surface **Refresh** again,
- show a small "Update looks stuck — try Refresh" hint.

Any genuine progress — including clearing to `null` on completion — resets the timer, so a healthy (even long-running) update is unaffected.

`tsc --noEmit` and `eslint` clean; `vite build` green.

## Context / related
Pairs with the backend root-cause fix [danvaneijck/trippinj#55](https://github.com/danvaneijck/trippinj/pull/55), which stops the large-token update from OOM-killing the worker in the first place. This PR is the UI resilience layer so a dead task can't permanently hide Refresh.

**Caveat:** after a hard kill the backend's Redis re-queue lock can linger up to its TTL (~25–66 min), during which a Refresh click no-ops. For the currently-wedged qunt the lock has already expired, so once both PRs deploy, clicking Refresh will repopulate it. Not browser-QA'd yet.