### PR TITLE
fix(img): show token logos when wsrv.nl proxy blocks the host

### DIFF
--- a/src/components/App/IpfsImage.tsx
+++ b/src/components/App/IpfsImage.tsx
@@ -1,18 +1,25 @@
 import { useState } from 'react';
 import tokenFallback from '../../assets/token.png';
-import { resolveImageUrl } from '../../utils/img';
+import { resolveImageUrl, directImageUrl } from '../../utils/img';
 
 // Renders a token logo from any source (Choice registry / IPFS / https), routed
-// through the wsrv.nl proxy for reliability and resizing. Falls back to a generic
-// token icon if the source still fails to load.
+// through the wsrv.nl proxy for reliability and resizing.
+//
+// Staged fallback on load error: proxied (wsrv.nl) → direct source URL → generic
+// token icon. wsrv.nl refuses some hosts by policy (e.g. postimg.cc → HTTP 400
+// "Domain or TLD blocked by policy"), which used to drop straight to the generic
+// icon; we now retry the source directly first so those logos still load.
 const IPFSImage = ({ ipfsPath, className, width }: any) => {
-    const [errored, setErrored] = useState(false);
+    const [stage, setStage] = useState(0);
 
     // `width` is used both for layout and to request a sensibly-sized (retina)
     // image from the proxy.
     const px = typeof width === 'number' ? width : Number(width) || 48;
-    const src =
-        errored || !ipfsPath ? tokenFallback : resolveImageUrl(ipfsPath, px * 2);
+    const src = !ipfsPath || stage >= 2
+        ? tokenFallback
+        : stage === 1
+            ? directImageUrl(ipfsPath)
+            : resolveImageUrl(ipfsPath, px * 2);
 
     return (
         <img
@@ -21,7 +28,7 @@ const IPFSImage = ({ ipfsPath, className, width }: any) => {
             className={className}
             alt="logo"
             loading="lazy"
-            onError={() => setErrored(true)}
+            onError={() => setStage((s) => s + 1)}
         />
     );
 };

--- a/src/utils/img.ts
+++ b/src/utils/img.ts
@@ -28,3 +28,13 @@ export const resolveImageUrl = (src?: string | null, size = 96): string => {
     const dim = Math.max(Math.round(size), 32);
     return `https://wsrv.nl/?url=${encodeURIComponent(toHttp(s))}&n=-1&w=${dim}&h=${dim}`;
 };
+
+// The un-proxied, gateway-normalised URL. Used as an intermediate fallback when
+// the wsrv.nl proxy refuses a source outright — e.g. it 400s "Domain or TLD
+// blocked by policy" for hosts like postimg.cc, even though the image loads fine
+// directly. Returns '' for empty input.
+export const directImageUrl = (src?: string | null): string => {
+    if (!src) return '';
+    const s = src.trim();
+    return s ? toHttp(s) : '';
+};


### PR DESCRIPTION
## Problem

Token logos route through the **wsrv.nl** image proxy, which refuses some hosts by policy:

```
GET wsrv.nl/?url=https://i.postimg.cc/…/IMG….jpg
→ HTTP 400 {"status":"error","code":400,"message":"Domain or TLD blocked by policy"}
```

The image itself loads fine **directly** (200, image/jpeg) — only the proxy blocks it. `IPFSImage` dropped straight from a proxy error to the bundled generic icon, so these logos never showed. Surfaced by SHROOM launch tokens (their metadata images are frequently `postimg.cc` links), but affects any token whose logo is on a wsrv-blocked domain.

## Fix

Give `IPFSImage` a **staged fallback**: proxied (wsrv.nl) → **direct source URL** → generic placeholder. On the first load error it retries the source directly (via new `directImageUrl`, the un-proxied gateway-normalised URL) before giving up. Hotlink-blocked/dead sources still end at the placeholder as before.

## Test
- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm run build` ✅
- Verified: `postimg.cc` direct = 200 image/jpeg; via wsrv.nl = 400 "blocked by policy".

🤖 Generated with [Claude Code](https://claude.com/claude-code)