### PR TITLE
feat(airdrop): Community BuyBack participants drop mode

### DIFF
--- a/src/modules/tokenUtils.tsx
+++ b/src/modules/tokenUtils.tsx
@@ -2041,6 +2041,160 @@ class TokenUtils {
         }
     }
 
+    // Injective Community BuyBack (mainnet) — the monthly buyback "Auction"
+    // CosmWasm contract. Participants join a round via `bid`; the reward basket
+    // is distributed pro-rata and the committed INJ is burned. Mainnet-only.
+    static BUYBACK_CONTRACT = "inj10n78w79xhxmytnuhjcck633nj4e7hrqaglgnfz";
+    static BUYBACK_LCD = "https://sentry.lcd.injective.network";
+
+    // Enumerate the completed/open buyback rounds by walking `get_round_info`
+    // from round 1 until the contract reports no such round. Returns lightweight
+    // metadata used to build the round picker (round #, month, INJ committed).
+    async fetchBuybackRounds() {
+        const contract = TokenUtils.BUYBACK_CONTRACT;
+        const lcd = TokenUtils.BUYBACK_LCD;
+        const rounds: {
+            round: number;
+            totalDeposit: number;
+            usedSlots: number;
+            startDate: number;
+            endDate: number;
+            chainRound: number;
+            basketTokens: number;
+        }[] = [];
+        for (let round = 1; round <= 120; round++) {
+            const query = btoa(JSON.stringify({ get_round_info: { round_id: round } }));
+            let data: any;
+            try {
+                data = await this.fetchWithRetry(
+                    `${lcd}/cosmwasm/wasm/v1/contract/${contract}/smart/${query}`,
+                    { method: "GET", headers: { "Content-Type": "application/json" } },
+                    2,
+                );
+            } catch {
+                break; // round doesn't exist yet — we've reached the end
+            }
+            const d = data?.data;
+            if (!d || d.id === undefined) break;
+            rounds.push({
+                round,
+                totalDeposit: Number(d.total_deposit || 0) / 1e18,
+                usedSlots: Number(d.used_slots || 0),
+                startDate: Number(d.start_date || 0),
+                endDate: Number(d.end_date || 0),
+                chainRound: Number(d.chain_round || 0),
+                basketTokens: Array.isArray(d.basket) ? d.basket.length : 0,
+            });
+        }
+        return rounds;
+    }
+
+    // Fetch every wallet that committed INJ in a given buyback round, with the
+    // amount they committed. The contract has no "list participants" query, so we
+    // iterate its raw state: participants live in a cw-storage-plus
+    // Map<(u64 round_id, Addr), UserRoundInfo> under the `user_round_info`
+    // namespace, and each entry's value already carries wallet + round_id +
+    // deposit — no key parsing needed. We craft the state start-key so pagination
+    // begins at this round's first entry and stop once it leaves the map or
+    // crosses into a later round.
+    //
+    // NB: whitelisting a wallet creates a user_round_info row with deposit 0, so a
+    // round can hold thousands of 0-deposit reservations (recent rounds have ~14k
+    // whitelisted vs ~280 who actually committed). We keep only deposit > 0 rows
+    // (the real committers) and, given `expectedTotalInj` (the round's
+    // total_deposit), stop early once the found deposits account for it — which
+    // also short-circuits the currently-open round (no deposits yet). Verified:
+    // per-round committer deposits sum exactly to the round's total_deposit.
+    // Mainnet-only.
+    async fetchBuybackParticipants(round: number, expectedTotalInj: number | undefined, setProgress: any) {
+        const contract = TokenUtils.BUYBACK_CONTRACT;
+        const lcd = TokenUtils.BUYBACK_LCD;
+
+        // start key = 0x00 <len> "user_round_info" 0x00 0x08 <round: u64 BE>
+        const nsBytes = new TextEncoder().encode("user_round_info");
+        const startKey = new Uint8Array(2 + nsBytes.length + 2 + 8);
+        startKey[0] = 0;
+        startKey[1] = nsBytes.length;
+        startKey.set(nsBytes, 2);
+        const roundOff = 2 + nsBytes.length;
+        startKey[roundOff] = 0;
+        startKey[roundOff + 1] = 8;
+        new DataView(startKey.buffer).setBigUint64(roundOff + 2, BigInt(round), false);
+
+        // Namespace prefix (0x00 <len> "user_round_info") shared by every entry in
+        // the map — used to detect when pagination walks past the map.
+        const nsPrefix = startKey.slice(0, 2 + nsBytes.length);
+
+        const bytesToB64 = (b: Uint8Array) => btoa(String.fromCharCode(...b));
+        const b64ToBytes = (s: string) => Uint8Array.from(atob(s), (c) => c.charCodeAt(0));
+        // The state endpoint marshals model keys as HexBytes, so `key` is an
+        // uppercase-hex string (not base64) — decode it directly to raw key bytes.
+        // (Values are plain base64; next_key is raw-bytes base64.)
+        const modelKeyBytes = (s: string) => {
+            const out = new Uint8Array(s.length >> 1);
+            for (let i = 0; i < out.length; i++) out[i] = parseInt(s.substr(i * 2, 2), 16);
+            return out;
+        };
+        const startsWith = (a: Uint8Array, p: Uint8Array) =>
+            a.length >= p.length && p.every((v, i) => a[i] === v);
+
+        // The open round can carry a very large 0-deposit whitelist with nothing
+        // committed yet — don't scan it at all.
+        if (expectedTotalInj !== undefined && expectedTotalInj <= 0) return [];
+
+        const participants: { address: string; deposit: number }[] = [];
+        let committedSum = 0;
+        let scanned = 0;
+        let pageKey: string | null = bytesToB64(startKey);
+        const maxPages = 500; // whitelist rows can be numerous; early-stop usually hits first
+
+        for (let page = 0; page < maxPages; page++) {
+            const url =
+                `${lcd}/cosmwasm/wasm/v1/contract/${contract}/state` +
+                `?pagination.limit=100&pagination.key=${encodeURIComponent(pageKey as string)}`;
+            const data = await this.fetchWithRetry(
+                url,
+                { method: "GET", headers: { "Content-Type": "application/json" } },
+                50,
+            );
+            const models: any[] = data?.models ?? [];
+            let done = false;
+            for (const m of models) {
+                if (!startsWith(modelKeyBytes(m.key), nsPrefix)) {
+                    done = true; // left the user_round_info map
+                    break;
+                }
+                let v: any;
+                try {
+                    v = JSON.parse(new TextDecoder().decode(b64ToBytes(m.value)));
+                } catch {
+                    continue;
+                }
+                if (typeof v?.round_id !== "number" || !v.wallet) continue;
+                if (v.round_id > round) {
+                    done = true; // crossed into a later round
+                    break;
+                }
+                if (v.round_id !== round) continue;
+                scanned++;
+                const deposit = Number(v.deposit || 0) / 1e18;
+                if (deposit > 0) {
+                    participants.push({ address: v.wallet, deposit });
+                    committedSum += deposit;
+                }
+            }
+            if (setProgress) setProgress(`${participants.length} participants (scanned ${scanned})`);
+            // Every committed INJ accounted for — the rest of the whitelist never bid.
+            if (expectedTotalInj !== undefined && expectedTotalInj > 0 && committedSum >= expectedTotalInj - 1e-6) {
+                done = true;
+            }
+            const nextKey = data?.pagination?.next_key;
+            if (done || !nextKey) break;
+            pageKey = nextKey;
+        }
+        return participants;
+    }
+
     async fetchProposalVoters(proposalId: any, blockNumber: any, setProgress: any) {
         const lcdBase = `https://sentry.lcd.injective.network/cosmos/gov/v1/proposals/${proposalId}/votes`;
         let voters: any[] = [];

--- a/src/views/Airdrop/index.tsx
+++ b/src/views/Airdrop/index.tsx
@@ -44,6 +44,7 @@ const DROP_MODE_OPTIONS: { value: DropMode; label: string }[] = [
     { value: "CSV", label: "Custom CSV file upload" },
     { value: "GOV", label: "Proposal Voters" },
     { value: "MITO", label: "Mito Vault Holders / Stakers" },
+    { value: "BUYBACK", label: "Community BuyBack Participants" },
 ];
 
 const isNativeDenom = (denom: string) =>
@@ -87,6 +88,13 @@ const Airdrop = () => {
     const [proposalNumber, setProposalNumber] = useState("417");
     const [blockHeight, setBlockHeight] = useState(76938079);
     const [attemptFindBlock, setAttemptFindBlock] = useState(true);
+
+    // Community BuyBack: pick a monthly round, then load its committed wallets.
+    // `total` carries the round's total_deposit (INJ) so the fetch can stop once
+    // every committer is found.
+    type BuybackRoundOption = { value: number; label: string; total: number };
+    const [buybackRounds, setBuybackRounds] = useState<BuybackRoundOption[]>([]);
+    const [buybackRound, setBuybackRound] = useState<BuybackRoundOption | null>(null);
 
     const [criteria, setCriteria] = useState("");
     const [description, setDescription] = useState("");
@@ -147,6 +155,45 @@ const Airdrop = () => {
         setAirdropDetails([]);
         setCsvInvalidRows([]);
     }, [dropMode.value]);
+
+    // Load the list of buyback rounds once, when the mode is first opened on
+    // mainnet (the program is mainnet-only). Newest round first.
+    useEffect(() => {
+        if (dropMode.value !== "BUYBACK" || currentNetwork !== "mainnet") return;
+        if (buybackRounds.length > 0) return;
+        let cancelled = false;
+        void (async () => {
+            try {
+                const module = new TokenUtils(networkConfig);
+                const rounds = await module.fetchBuybackRounds();
+                if (cancelled) return;
+                const opts = rounds
+                    .slice()
+                    .reverse()
+                    .map((r) => ({
+                        value: r.round,
+                        total: r.totalDeposit,
+                        label: `Round ${r.round} — ${
+                            r.startDate ? dayjs.unix(r.startDate).format("MMM YYYY") : "?"
+                        } · ${r.totalDeposit.toLocaleString(undefined, { maximumFractionDigits: 0 })} INJ committed`,
+                    }));
+                setBuybackRounds(opts);
+                if (opts.length) setBuybackRound((prev) => prev ?? opts[0]);
+            } catch (e) {
+                console.log(e);
+            }
+        })();
+        return () => {
+            cancelled = true;
+        };
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [dropMode.value, currentNetwork, networkConfig]);
+
+    // Changing the selected round invalidates any loaded participant list.
+    useEffect(() => {
+        if (dropMode.value === "BUYBACK") setAirdropDetails([]);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [buybackRound]);
 
     const getMitoVaultHolders = useCallback(
         async (vaultAddress: any) => {
@@ -250,6 +297,10 @@ const Airdrop = () => {
         } else if (dropMode.value === "MITO") {
             criteriaUpdate = `Holders of ${mitoHolderType === "stake" ? "staked" : "all"} LP tokens in the ${selectedMitoVault.value.baseToken.name} mito vault at ${now}`;
             descriptionUpdate = `${mode} drop of ${totalToDrop} ${tokenInfo.symbol} to holders of ${selectedMitoVault.value.baseToken.name} mito vault tokens`;
+        } else if (dropMode.value === "BUYBACK") {
+            const roundLabel = buybackRound ? `round ${buybackRound.value}` : "a round";
+            criteriaUpdate = `Participants of Community BuyBack ${roundLabel} at ${now}`;
+            descriptionUpdate = `${mode} drop of ${totalToDrop} ${tokenInfo.symbol} to Community BuyBack ${roundLabel} participants`;
         }
 
         setCriteria(criteriaUpdate);
@@ -266,6 +317,7 @@ const Airdrop = () => {
         proposalNumber,
         selectedMitoVault,
         mitoHolderType,
+        buybackRound,
     ]);
 
     async function fetchBlock(height: any) {
@@ -622,6 +674,39 @@ const Airdrop = () => {
             setLoading(false);
         }
     }, [getProposalAndBlockHeight, proposalNumber, networkConfig, dropAmount, attemptFindBlock, blockHeight]);
+
+    const getBuybackParticipants = useCallback(async () => {
+        if (!buybackRound) {
+            setError("select a buyback round");
+            return;
+        }
+        setAirdropDetails([]);
+        setLoading(true);
+        setError(null);
+        try {
+            const module = new TokenUtils(networkConfig);
+            const participants = await module.fetchBuybackParticipants(
+                buybackRound.value,
+                buybackRound.total,
+                setProgress,
+            );
+            const base: AirdropRecipient[] = participants
+                .map((p) => ({
+                    address: p.address,
+                    balance: p.deposit,
+                    amountToAirdrop: 0,
+                    percentToAirdrop: 0,
+                    includeInDrop: true,
+                }))
+                .sort((a, b) => (b.balance ?? 0) - (a.balance ?? 0));
+            setAirdropDetails(allocate(base, activeDist, dropAmount));
+            setLoading(false);
+        } catch (e) {
+            console.log(e);
+            setError((e as any)?.message ?? "Failed to fetch buyback participants");
+            setLoading(false);
+        }
+    }, [buybackRound, networkConfig, activeDist, dropAmount]);
 
     const csvTotal = useMemo(
         () => airdropDetails.reduce((sum, r) => sum + (r.includeInDrop ? Number(r.amountToAirdrop) || 0 : 0), 0),
@@ -1026,6 +1111,74 @@ const Airdrop = () => {
                                                             network={currentNetwork}
                                                             csvFilename={`airdrop-${tokenSymbol}-gov.csv`}
                                                         />
+                                                    )}
+                                                </div>
+                                            )}
+
+                                            {dropMode.value === "BUYBACK" && (
+                                                <div>
+                                                    {currentNetwork !== "mainnet" ? (
+                                                        <div className="text-amber-400 text-sm">
+                                                            Community BuyBack is a mainnet-only program. Switch to
+                                                            mainnet to load round participants.
+                                                        </div>
+                                                    ) : (
+                                                        <>
+                                                            <div className="space-y-2">
+                                                                <label className="text-base font-bold text-white">
+                                                                    BuyBack round
+                                                                </label>
+                                                                <Select
+                                                                    className="text-black"
+                                                                    value={buybackRound}
+                                                                    onChange={setBuybackRound}
+                                                                    options={buybackRounds}
+                                                                    isLoading={buybackRounds.length === 0}
+                                                                    placeholder={
+                                                                        buybackRounds.length
+                                                                            ? "Select a round"
+                                                                            : "Loading rounds…"
+                                                                    }
+                                                                />
+                                                                <div className="text-xs text-slate-400">
+                                                                    Wallets that committed INJ in the selected monthly
+                                                                    buyback round.
+                                                                </div>
+                                                            </div>
+                                                            <div className="mt-4 mb-2">
+                                                                <DistributionToggle
+                                                                    value={distMode}
+                                                                    onChange={setDistMode}
+                                                                />
+                                                            </div>
+                                                            <button
+                                                                disabled={loading || !buybackRound}
+                                                                onClick={() => {
+                                                                    void getBuybackParticipants();
+                                                                }}
+                                                                className="bg-gray-800 hover:bg-gray-700 rounded-lg p-2 w-full text-white mt-2 shadow-lg disabled:opacity-50"
+                                                            >
+                                                                Get participants
+                                                            </button>
+                                                            {airdropDetails.length > 0 && (
+                                                                <AirdropListSection
+                                                                    recipients={airdropDetails}
+                                                                    setRecipients={setAirdropDetails}
+                                                                    distMode={activeDist}
+                                                                    total={dropAmount}
+                                                                    tokenSymbol={tokenSymbol}
+                                                                    tokenDecimals={tokenDecimals}
+                                                                    sourceSymbol="INJ"
+                                                                    sourceDecimals={2}
+                                                                    filter="none"
+                                                                    columns={{ include: true, position: true, balance: true }}
+                                                                    network={currentNetwork}
+                                                                    csvFilename={`airdrop-${tokenSymbol}-buyback-round-${
+                                                                        buybackRound?.value ?? ""
+                                                                    }.csv`}
+                                                                />
+                                                            )}
+                                                        </>
                                                     )}
                                                 </div>
                                             )}

--- a/src/views/Airdrop/types.ts
+++ b/src/views/Airdrop/types.ts
@@ -2,7 +2,7 @@
 
 export type DistMode = "fair" | "proportionate";
 
-export type DropMode = "NFT" | "TOKEN" | "CSV" | "GOV" | "MITO";
+export type DropMode = "NFT" | "TOKEN" | "CSV" | "GOV" | "MITO" | "BUYBACK";
 
 export type VoteOption =
     | "VOTE_OPTION_YES"


### PR DESCRIPTION
## What

Adds a new airdrop drop mode **"Community BuyBack Participants"** to the airdrop tool, working like the existing *Proposal Voters* mode: pick a monthly [Injective Community BuyBack](https://docs.injective.network/defi/community-buyback) round, load the wallets that committed INJ in that round, and distribute — **fair** (equal) or **proportionate** (weighted by INJ committed).

## How participants are fetched

The BuyBack is a CosmWasm contract (mainnet `inj10n78w79xhxmytnuhjcck633nj4e7hrqaglgnfz`, "Auction", code_id 1975). It exposes **no query that lists a round's participants**, so `fetchBuybackParticipants` enumerates the contract's raw state:

- Participants live in a cw-storage-plus `Map<(u64 round_id, Addr), UserRoundInfo>` under the `user_round_info` namespace; each entry's **value** already carries `wallet` + `round_id` + `deposit`.
- We craft the state pagination start-key (`\x00\x0f user_round_info \x00\x08 <round:u64 BE>`) so iteration begins at the target round's first entry and stops when it leaves the map or crosses into a later round.
- Whitelisting a wallet creates a `deposit: 0` row, so recent rounds hold ~14k whitelisted reservations vs ~280 actual committers. We keep only `deposit > 0` (real committers) and **stop early** once found deposits sum to the round's `total_deposit` — which also instantly short-circuits the currently-open round.

`fetchBuybackRounds` builds the round picker via `get_round_info`. The mode is **gated to mainnet** (the program is mainnet-only).

### Gotcha handled
The LCD `/state` endpoint returns `models[].key` as an **uppercase-hex string** (`HexBytes`), *not* base64 — decoded directly. (`models[].value` is plain base64; `pagination.next_key` is raw-bytes base64.)

## Verification

Enumerated committers match each round's on-chain `total_deposit` exactly:

| Round | Committers | INJ | Pages |
|------:|-----------:|----:|------:|
| 1 | 232 | 8,703.43 | 3 |
| 2 | 234 | 36,939.50 | 3 |
| 3 | 235 | 43,199.43 | 3 |
| 5 | 236 | 54,999.92 | 3 |
| 9 | 284 | 39,300.00 | 143 |
| 10 (open) | 0 | 0 | 0 (short-circuit) |

`tsc`, `eslint`, and `vite build` all pass clean.

## Notes
- Round 9 (and other recent rounds) scan a ~14k-row whitelist to find the real committers (~143 LCD pages, ~1 min) — there's a live progress readout. Older rounds are instant.
- Files: `views/Airdrop/types.ts`, `views/Airdrop/index.tsx`, `modules/tokenUtils.tsx`.
- ⚠️ Not yet QA'd in-app; this repo auto-deploys, so worth a manual click-through on mainnet before/after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)