### PR TITLE
feat(ecosystem): Ecosystem Explorer — all-token activity comparison table

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ import PreSaleTool from './views/PresaleTool';
 import DojoWhitelist from './views/DojoWhitelist';
 import Header from './components/App/Header';
 import ShroomHub from './views/ShroomHub';
+import EcosystemExplorer from './views/EcosystemExplorer';
 import QuntUnwrap from './views/QuntUnwrap';
 import WalletExport from './views/WalletExport';
 import WalletSelectModal from './components/Modals/WalletSelectModal';
@@ -61,6 +62,7 @@ const App = () => {
           <Route path="/pre-sale-tool" element={<PreSaleTool />} />
           <Route path="/dojo-whitelist" element={<DojoWhitelist />} />
           <Route path="/shroom-hub" element={<ShroomHub />} />
+          <Route path="/ecosystem" element={<EcosystemExplorer />} />
           <Route path="/qunt-unwrap" element={<QuntUnwrap />} />
           <Route path="/wallet-export" element={<WalletExport />} />
           <Route path="/" element={<Home />} />

--- a/src/components/App/Header.tsx
+++ b/src/components/App/Header.tsx
@@ -29,6 +29,9 @@ const Header = () => {
                     <Link to="/shroom-hub" className={getLinkStyle('/shroom-hub')}>
                         Info
                     </Link>
+                    <Link to="/ecosystem" className={getLinkStyle('/ecosystem')}>
+                        Ecosystem
+                    </Link>
                     <Link to="/token-holders" className={getLinkStyle('/token-holders')}>
                         Holders
                     </Link>
@@ -107,6 +110,9 @@ const Header = () => {
                     </Link>
                     <Link to="/shroom-hub" className={getLinkStyle('/shroom-hub')} onClick={toggleMenu}>
                         Info
+                    </Link>
+                    <Link to="/ecosystem" className={getLinkStyle('/ecosystem')} onClick={toggleMenu}>
+                        Ecosystem Explorer
                     </Link>
                     <Link to="/token-holders" className={getLinkStyle('/token-holders')} onClick={toggleMenu}>
                         Holder tool

--- a/src/views/EcosystemExplorer/data.ts
+++ b/src/views/EcosystemExplorer/data.ts
@@ -1,0 +1,163 @@
+// Ecosystem Explorer data model — a comparison table of every token Choice
+// indexes, with per-window activity stats.
+//
+// Three independent sources, merged by token address so each degrades alone:
+//   1. Choice GraphQL `tokens_token` + nested `analytics_tokenstats` — identity,
+//      price, mcap/fdv, liquidity, price change over all five windows.
+//   2. Choice GraphQL `analytics_tokenmarketstats` — cross-venue volume / swaps /
+//      unique traders over 24h/7d/30d/90d (backend PR #221). Queried separately
+//      so the page still renders if the field isn't deployed yet.
+//   3. trippinj Hasura `token_tracker_token` — holder counts, only for tokens the
+//      holder tracker has indexed (same source as the Token Holders page).
+
+import { gql } from '@apollo/client';
+
+export type StatWindow = '24h' | '7d' | '30d' | '90d';
+export const STAT_WINDOWS: StatWindow[] = ['24h', '7d', '30d', '90d'];
+
+export const ECOSYSTEM_TOKENS_QUERY = gql`
+    query EcosystemTokens {
+        tokens_token(limit: 5000) {
+            address
+            symbol
+            name
+            decimals
+            logo
+            show_on_ui
+            stats {
+                current_price_usd
+                market_cap
+                fdv
+                total_liquidity_usd
+                price_change_usd_24h
+                price_change_usd_7d
+                price_change_usd_30d
+                price_change_usd_90d
+                updated_at
+            }
+        }
+    }
+`;
+
+// Kept separate from the token query: until the TokenMarketStats backend ships,
+// this query validation-fails and the rest of the table must keep working.
+export const MARKET_STATS_QUERY = gql`
+    query EcosystemMarketStats {
+        analytics_tokenmarketstats {
+            token_id
+            volume_usd_24h
+            volume_usd_7d
+            volume_usd_30d
+            volume_usd_90d
+            swaps_24h
+            swaps_7d
+            swaps_30d
+            swaps_90d
+            traders_24h
+            traders_7d
+            traders_30d
+            traders_90d
+            updated_at
+        }
+    }
+`;
+
+// trippinj backend (DEFAULT Apollo client, not choiceClient): per-token holder
+// counts via the nested balances aggregate, for every tracked token at once.
+export const HOLDER_COUNTS_QUERY = gql`
+    query EcosystemHolderCounts {
+        token_tracker_token {
+            address
+            holders_last_updated
+            holder_count: balances_aggregate(where: { balance: { _gt: 0 } }) {
+                aggregate {
+                    count
+                }
+            }
+        }
+    }
+`;
+
+export type PerWindow = Record<StatWindow, number>;
+
+export interface EcoTokenRow {
+    address: string;
+    symbol: string;
+    name: string | null;
+    logo: string | null;
+    listed: boolean;
+    priceUsd: number;
+    marketCap: number;
+    fdv: number;
+    liquidityUsd: number;
+    /** price change % keyed by window (null = not enough history) */
+    change: Record<StatWindow, number | null>;
+    volume: PerWindow;
+    swaps: PerWindow;
+    traders: PerWindow;
+    holders: number | null;
+    holdersUpdated: string | null;
+    /** true once a TokenMarketStats row backed the volume/traders columns */
+    hasMarketStats: boolean;
+}
+
+const zeroWindows = (): PerWindow => ({ '24h': 0, '7d': 0, '30d': 0, '90d': 0 });
+
+export const buildRows = (
+    tokens: any[] | undefined,
+    marketStats: any[] | undefined,
+    holderRows: any[] | undefined,
+): EcoTokenRow[] => {
+    const byAddress = new Map<string, EcoTokenRow>();
+
+    for (const t of tokens ?? []) {
+        const s = Array.isArray(t.stats) ? t.stats[0] : t.stats;
+        byAddress.set(t.address, {
+            address: t.address,
+            symbol: t.symbol || '?',
+            name: t.name ?? null,
+            logo: t.logo ?? null,
+            listed: !!t.show_on_ui,
+            priceUsd: Number(s?.current_price_usd) || 0,
+            marketCap: Number(s?.market_cap) || 0,
+            fdv: Number(s?.fdv) || 0,
+            liquidityUsd: Number(s?.total_liquidity_usd) || 0,
+            change: {
+                '24h': s?.price_change_usd_24h != null ? Number(s.price_change_usd_24h) : null,
+                '7d': s?.price_change_usd_7d != null ? Number(s.price_change_usd_7d) : null,
+                '30d': s?.price_change_usd_30d != null ? Number(s.price_change_usd_30d) : null,
+                '90d': s?.price_change_usd_90d != null ? Number(s.price_change_usd_90d) : null,
+            },
+            volume: zeroWindows(),
+            swaps: zeroWindows(),
+            traders: zeroWindows(),
+            holders: null,
+            holdersUpdated: null,
+            hasMarketStats: false,
+        });
+    }
+
+    for (const m of marketStats ?? []) {
+        const row = byAddress.get(m.token_id);
+        if (!row) continue;
+        row.hasMarketStats = true;
+        for (const w of STAT_WINDOWS) {
+            const suffix = w;
+            row.volume[w] = Number(m[`volume_usd_${suffix}`]) || 0;
+            row.swaps[w] = Number(m[`swaps_${suffix}`]) || 0;
+            row.traders[w] = Number(m[`traders_${suffix}`]) || 0;
+        }
+    }
+
+    for (const h of holderRows ?? []) {
+        const row = byAddress.get(h.address);
+        if (!row) continue;
+        const count = h.holder_count?.aggregate?.count;
+        if (count != null) {
+            row.holders = Number(count);
+            row.holdersUpdated = h.holders_last_updated ?? null;
+        }
+    }
+
+    return [...byAddress.values()];
+};

--- a/src/views/EcosystemExplorer/index.tsx
+++ b/src/views/EcosystemExplorer/index.tsx
@@ -1,0 +1,483 @@
+// Ecosystem Explorer — a sortable, filterable comparison table of every token in
+// the Injective/Choice ecosystem: price, price change, cross-venue volume, unique
+// traders, swaps, liquidity, market cap and holders, with the activity columns
+// switchable between 24h / 7d / 30d / 90d windows.
+//
+// Data: Choice public GraphQL (token registry + TokenMarketStats windowed rollup)
+// merged with trippinj's holder tracker. See ./data.ts for the source split.
+
+import { useEffect, useMemo, useState } from 'react';
+import { useQuery } from '@apollo/client';
+import { toast } from 'react-toastify';
+import { ClipLoader } from 'react-spinners';
+import { FiSearch } from 'react-icons/fi';
+
+import Footer from '../../components/App/Footer';
+import choiceClient from '../../utils/choiceApolloClient';
+import { resolveImageUrl } from '../../utils/img';
+import {
+    formatAmount,
+    formatPrice,
+    formatUsd,
+    shortAddr,
+    timeAgo,
+} from '../../components/App/markets/format';
+import { SectionHeader } from '../ShroomHub/ui';
+import { PANEL, TOGGLE_WRAP, toggleBtn } from '../ShroomHub/styles';
+import {
+    buildRows,
+    ECOSYSTEM_TOKENS_QUERY,
+    type EcoTokenRow,
+    HOLDER_COUNTS_QUERY,
+    MARKET_STATS_QUERY,
+    STAT_WINDOWS,
+    type StatWindow,
+} from './data';
+
+const MAX_RENDERED_ROWS = 300;
+
+type SortKey =
+    | 'symbol'
+    | 'price'
+    | 'change'
+    | 'volume'
+    | 'traders'
+    | 'swaps'
+    | 'liquidity'
+    | 'marketCap'
+    | 'holders';
+
+interface Prefs {
+    window: StatWindow;
+    sortKey: SortKey;
+    sortAsc: boolean;
+    listedOnly: boolean;
+    minLiquidity: number;
+}
+
+const DEFAULT_PREFS: Prefs = {
+    window: '24h',
+    sortKey: 'volume',
+    sortAsc: false,
+    listedOnly: true,
+    minLiquidity: 0,
+};
+
+const PREFS_KEY = 'ecosystem-explorer-prefs';
+
+const loadPrefs = (): Prefs => {
+    try {
+        const raw = localStorage.getItem(PREFS_KEY);
+        if (raw) return { ...DEFAULT_PREFS, ...JSON.parse(raw) };
+    } catch {
+        /* corrupted prefs -> defaults */
+    }
+    return DEFAULT_PREFS;
+};
+
+const sortValue = (r: EcoTokenRow, key: SortKey, w: StatWindow): number | string => {
+    switch (key) {
+        case 'symbol':
+            return r.symbol.toLowerCase();
+        case 'price':
+            return r.priceUsd;
+        case 'change':
+            return r.change[w] ?? Number.NEGATIVE_INFINITY;
+        case 'volume':
+            return r.volume[w];
+        case 'traders':
+            return r.traders[w];
+        case 'swaps':
+            return r.swaps[w];
+        case 'liquidity':
+            return r.liquidityUsd;
+        case 'marketCap':
+            return r.marketCap;
+        case 'holders':
+            return r.holders ?? -1;
+    }
+};
+
+const ChangeCell = ({ value }: { value: number | null }) => {
+    if (value == null) return <span className="text-white/30">—</span>;
+    const up = value >= 0;
+    return (
+        <span className={up ? 'text-emerald-400' : 'text-rose-400'}>
+            {up ? '+' : ''}
+            {value.toFixed(2)}%
+        </span>
+    );
+};
+
+const TokenAvatar = ({ logo, symbol }: { logo: string | null; symbol: string }) => {
+    const [failed, setFailed] = useState(false);
+    const url = resolveImageUrl(logo, 64);
+    if (!url || failed) {
+        return (
+            <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-white/10 text-xs font-bold text-white/60">
+                {symbol.slice(0, 1).toUpperCase()}
+            </div>
+        );
+    }
+    return (
+        <img
+            src={url}
+            alt={symbol}
+            className="h-7 w-7 shrink-0 rounded-full bg-white/10 object-cover"
+            onError={() => setFailed(true)}
+        />
+    );
+};
+
+const LIQ_FILTERS = [
+    { label: 'Any liq', value: 0 },
+    { label: '>$100', value: 100 },
+    { label: '>$1k', value: 1_000 },
+    { label: '>$10k', value: 10_000 },
+] as const;
+
+const Th = ({
+    label,
+    k,
+    align = 'right',
+    sortKey,
+    sortAsc,
+    onSort,
+}: {
+    label: string;
+    k?: SortKey;
+    align?: 'left' | 'right';
+    sortKey: SortKey;
+    sortAsc: boolean;
+    onSort: (k: SortKey) => void;
+}) => (
+    <th
+        className={`whitespace-nowrap px-3 py-2 ${align === 'left' ? 'text-left' : 'text-right'} text-[11px] font-medium uppercase tracking-wide text-white/40 ${
+            k ? 'cursor-pointer select-none hover:text-white/70' : ''
+        }`}
+        onClick={k ? () => onSort(k) : undefined}
+    >
+        {label}
+        {k && sortKey === k && <span className="ml-1 text-trippyYellow">{sortAsc ? '▲' : '▼'}</span>}
+    </th>
+);
+
+const EcosystemExplorer = () => {
+    const [prefs, setPrefs] = useState<Prefs>(loadPrefs);
+    const [search, setSearch] = useState('');
+    const { window: win, sortKey, sortAsc, listedOnly, minLiquidity } = prefs;
+
+    // Render-safe clock for the "x ago" labels (react-hooks/purity forbids
+    // calling Date.now() during render).
+    const [nowTs, setNowTs] = useState(() => Date.now());
+    useEffect(() => {
+        const id = window.setInterval(() => setNowTs(Date.now()), 60_000);
+        return () => window.clearInterval(id);
+    }, []);
+
+    useEffect(() => {
+        try {
+            localStorage.setItem(PREFS_KEY, JSON.stringify(prefs));
+        } catch {
+            /* storage full/blocked — prefs just won't persist */
+        }
+    }, [prefs]);
+
+    const tokensQ = useQuery(ECOSYSTEM_TOKENS_QUERY, {
+        client: choiceClient,
+        fetchPolicy: 'cache-and-network',
+        pollInterval: 120_000,
+    });
+    // Separate query + errorPolicy so the table keeps rendering while the
+    // TokenMarketStats backend (windowed volume/traders) isn't deployed yet.
+    const marketQ = useQuery(MARKET_STATS_QUERY, {
+        client: choiceClient,
+        fetchPolicy: 'cache-and-network',
+        pollInterval: 120_000,
+        errorPolicy: 'all',
+    });
+    const holdersQ = useQuery(HOLDER_COUNTS_QUERY, {
+        fetchPolicy: 'cache-and-network',
+        pollInterval: 300_000,
+        errorPolicy: 'all',
+    });
+
+    const rows = useMemo(
+        () =>
+            buildRows(
+                tokensQ.data?.tokens_token,
+                marketQ.data?.analytics_tokenmarketstats,
+                holdersQ.data?.token_tracker_token,
+            ),
+        [tokensQ.data, marketQ.data, holdersQ.data],
+    );
+
+    const marketStatsLive = rows.some((r) => r.hasMarketStats);
+    const marketStatsUpdated: string | null =
+        marketQ.data?.analytics_tokenmarketstats?.[0]?.updated_at ?? null;
+
+    const visible = useMemo(() => {
+        const q = search.trim().toLowerCase();
+        const filtered = rows.filter((r) => {
+            if (listedOnly && !r.listed) return false;
+            if (r.liquidityUsd < minLiquidity) return false;
+            if (!q) return true;
+            return (
+                r.symbol.toLowerCase().includes(q) ||
+                (r.name ?? '').toLowerCase().includes(q) ||
+                r.address.toLowerCase().includes(q)
+            );
+        });
+        const dir = sortAsc ? 1 : -1;
+        filtered.sort((a, b) => {
+            const va = sortValue(a, sortKey, win);
+            const vb = sortValue(b, sortKey, win);
+            if (va < vb) return -dir;
+            if (va > vb) return dir;
+            // Stable, meaningful tie-break (e.g. volume all-zero pre-deploy).
+            return b.liquidityUsd - a.liquidityUsd;
+        });
+        return filtered;
+    }, [rows, search, listedOnly, minLiquidity, sortKey, sortAsc, win]);
+
+    const setSort = (key: SortKey) =>
+        setPrefs((p) =>
+            p.sortKey === key
+                ? { ...p, sortAsc: !p.sortAsc }
+                : { ...p, sortKey: key, sortAsc: key === 'symbol' },
+        );
+
+    const copyAddress = (address: string) => {
+        navigator.clipboard
+            .writeText(address)
+            .then(() => toast.success('Address copied'))
+            .catch(() => toast.error('Copy failed'));
+    };
+
+    const loading = tokensQ.loading && !tokensQ.data;
+    const thProps = { sortKey, sortAsc, onSort: setSort };
+
+    return (
+        <>
+            <div className="flex min-h-screen flex-col bg-customGray">
+                <div className="mx-auto w-full max-w-7xl space-y-4 px-3 pt-20 pb-16 sm:px-5 md:pt-24">
+                    <SectionHeader
+                        eyebrow="Injective ecosystem"
+                        title="Ecosystem Explorer"
+                        sub="Compare every token's activity across Choice AMM, CLMM and Helix orderbook markets."
+                    >
+                        <div className={TOGGLE_WRAP}>
+                            {STAT_WINDOWS.map((w) => (
+                                <button
+                                    key={w}
+                                    className={toggleBtn(win === w)}
+                                    onClick={() => setPrefs((p) => ({ ...p, window: w }))}
+                                >
+                                    {w.toUpperCase()}
+                                </button>
+                            ))}
+                        </div>
+                    </SectionHeader>
+
+                    <div className="flex flex-wrap items-center gap-2">
+                        <div className="relative">
+                            <FiSearch className="pointer-events-none absolute top-1/2 left-2.5 -translate-y-1/2 text-white/40" />
+                            <input
+                                value={search}
+                                onChange={(e) => setSearch(e.target.value)}
+                                placeholder="Search symbol, name or address"
+                                className="w-64 rounded-lg border border-white/10 bg-black/20 py-1.5 pr-3 pl-8 text-sm text-white placeholder-white/30 focus:border-trippyYellow/60 focus:outline-hidden"
+                            />
+                        </div>
+                        <div className={TOGGLE_WRAP}>
+                            <button
+                                className={toggleBtn(listedOnly)}
+                                onClick={() => setPrefs((p) => ({ ...p, listedOnly: true }))}
+                            >
+                                Listed
+                            </button>
+                            <button
+                                className={toggleBtn(!listedOnly)}
+                                onClick={() => setPrefs((p) => ({ ...p, listedOnly: false }))}
+                            >
+                                All tokens
+                            </button>
+                        </div>
+                        <div className={TOGGLE_WRAP}>
+                            {LIQ_FILTERS.map((f) => (
+                                <button
+                                    key={f.value}
+                                    className={toggleBtn(minLiquidity === f.value)}
+                                    onClick={() =>
+                                        setPrefs((p) => ({ ...p, minLiquidity: f.value }))
+                                    }
+                                >
+                                    {f.label}
+                                </button>
+                            ))}
+                        </div>
+                        <div className="ml-auto text-xs text-white/40">
+                            {visible.length} tokens
+                            {marketStatsUpdated && (
+                                <>
+                                    {' '}
+                                    · stats{' '}
+                                    {timeAgo(new Date(marketStatsUpdated).getTime(), nowTs)} ago
+                                </>
+                            )}
+                        </div>
+                    </div>
+
+                    {!marketStatsLive && !marketQ.loading && (
+                        <div className="rounded-lg border border-amber-400/20 bg-amber-400/5 px-3 py-2 text-xs text-amber-200/80">
+                            Windowed volume &amp; trader stats aren&apos;t live on the Choice API
+                            yet — those columns will populate once the backend rollup is deployed.
+                        </div>
+                    )}
+
+                    <div className={`${PANEL} overflow-x-auto`}>
+                        {loading ? (
+                            <div className="flex items-center justify-center py-24">
+                                <ClipLoader size={28} color="#facc15" />
+                            </div>
+                        ) : (
+                            <table className="w-full min-w-245 text-sm">
+                                <thead>
+                                    <tr className="border-b border-white/10">
+                                        <Th label="#" {...thProps} />
+                                        <Th label="Token" k="symbol" align="left" {...thProps} />
+                                        <Th label="Price" k="price" {...thProps} />
+                                        <Th label={`Δ ${win}`} k="change" {...thProps} />
+                                        <Th label={`Vol ${win}`} k="volume" {...thProps} />
+                                        <Th label={`Traders ${win}`} k="traders" {...thProps} />
+                                        <Th label={`Swaps ${win}`} k="swaps" {...thProps} />
+                                        <Th label="Liquidity" k="liquidity" {...thProps} />
+                                        <Th label="Mcap" k="marketCap" {...thProps} />
+                                        <Th label="Holders" k="holders" {...thProps} />
+                                    </tr>
+                                </thead>
+                                <tbody className="tabular-nums">
+                                    {visible.slice(0, MAX_RENDERED_ROWS).map((r, i) => (
+                                        <tr
+                                            key={r.address}
+                                            className="border-b border-white/5 hover:bg-white/2"
+                                        >
+                                            <td className="px-3 py-2 text-right text-white/30">
+                                                {i + 1}
+                                            </td>
+                                            <td className="px-3 py-2">
+                                                <div className="flex items-center gap-2.5">
+                                                    <TokenAvatar logo={r.logo} symbol={r.symbol} />
+                                                    <div className="min-w-0">
+                                                        <div className="flex items-center gap-1.5 font-semibold text-white">
+                                                            {r.symbol}
+                                                            {!r.listed && (
+                                                                <span className="rounded bg-white/10 px-1 py-px text-[9px] font-medium text-white/40 uppercase">
+                                                                    unlisted
+                                                                </span>
+                                                            )}
+                                                        </div>
+                                                        <button
+                                                            className="block max-w-40 truncate text-left text-[11px] text-white/35 hover:text-white/70"
+                                                            title={`${r.name ?? r.symbol} — click to copy ${r.address}`}
+                                                            onClick={() => copyAddress(r.address)}
+                                                        >
+                                                            {r.name || shortAddr(r.address)}
+                                                        </button>
+                                                    </div>
+                                                </div>
+                                            </td>
+                                            <td className="px-3 py-2 text-right text-white">
+                                                ${formatPrice(r.priceUsd)}
+                                            </td>
+                                            <td className="px-3 py-2 text-right">
+                                                <ChangeCell value={r.change[win]} />
+                                            </td>
+                                            <td className="px-3 py-2 text-right text-white">
+                                                {r.hasMarketStats ? (
+                                                    formatUsd(r.volume[win])
+                                                ) : (
+                                                    <span className="text-white/30">—</span>
+                                                )}
+                                            </td>
+                                            <td className="px-3 py-2 text-right text-white/80">
+                                                {r.hasMarketStats ? (
+                                                    formatAmount(r.traders[win])
+                                                ) : (
+                                                    <span className="text-white/30">—</span>
+                                                )}
+                                            </td>
+                                            <td className="px-3 py-2 text-right text-white/60">
+                                                {r.hasMarketStats ? (
+                                                    formatAmount(r.swaps[win])
+                                                ) : (
+                                                    <span className="text-white/30">—</span>
+                                                )}
+                                            </td>
+                                            <td className="px-3 py-2 text-right text-white/80">
+                                                {r.liquidityUsd > 0 ? (
+                                                    formatUsd(r.liquidityUsd)
+                                                ) : (
+                                                    <span className="text-white/30">—</span>
+                                                )}
+                                            </td>
+                                            <td className="px-3 py-2 text-right text-white/80">
+                                                {r.marketCap > 0 ? (
+                                                    formatUsd(r.marketCap)
+                                                ) : (
+                                                    <span className="text-white/30">—</span>
+                                                )}
+                                            </td>
+                                            <td
+                                                className="px-3 py-2 text-right text-white/80"
+                                                title={
+                                                    r.holdersUpdated
+                                                        ? `Holder snapshot ${timeAgo(new Date(r.holdersUpdated).getTime(), nowTs)} ago (trippy tracker)`
+                                                        : 'Not tracked yet — index it via the Holder tool'
+                                                }
+                                            >
+                                                {r.holders != null ? (
+                                                    formatAmount(r.holders)
+                                                ) : (
+                                                    <span className="text-white/30">—</span>
+                                                )}
+                                            </td>
+                                        </tr>
+                                    ))}
+                                    {visible.length === 0 && (
+                                        <tr>
+                                            <td
+                                                colSpan={10}
+                                                className="px-3 py-10 text-center text-white/40"
+                                            >
+                                                No tokens match the current filters.
+                                            </td>
+                                        </tr>
+                                    )}
+                                </tbody>
+                            </table>
+                        )}
+                        {visible.length > MAX_RENDERED_ROWS && (
+                            <div className="border-t border-white/5 px-3 py-2 text-center text-xs text-white/40">
+                                Showing top {MAX_RENDERED_ROWS} of {visible.length} — refine the
+                                filters to narrow down.
+                            </div>
+                        )}
+                    </div>
+
+                    <p className="text-[11px] leading-relaxed text-white/30">
+                        Volume, traders and swaps are unioned across Choice AMM, CLMM and Helix
+                        spot orderbook markets. A trade counts toward both sides of its pair, so
+                        quote tokens (INJ, USDT…) carry everything traded against them. Traders
+                        are unique wallets, deduplicated across venues. Holder counts come from
+                        the trippy holder tracker and only exist for tokens it has indexed —
+                        hover for snapshot age.
+                    </p>
+                </div>
+                <Footer />
+            </div>
+        </>
+    );
+};
+
+export default EcosystemExplorer;

--- a/src/views/EcosystemExplorer/index.tsx
+++ b/src/views/EcosystemExplorer/index.tsx
@@ -183,17 +183,21 @@ const EcosystemExplorer = () => {
         }
     }, [prefs]);
 
+    // Backend refreshes TokenStats every minute — 60s keeps price/Δ%/liquidity
+    // near-live without re-pulling the 500KB all-tokens payload too often.
     const tokensQ = useQuery(ECOSYSTEM_TOKENS_QUERY, {
         client: choiceClient,
         fetchPolicy: 'cache-and-network',
-        pollInterval: 120_000,
+        pollInterval: 60_000,
     });
     // Separate query + errorPolicy so the table keeps rendering while the
     // TokenMarketStats backend (windowed volume/traders) isn't deployed yet.
+    // The backend's fast lane rewrites the *_24h columns every minute; a 30s
+    // poll on this small (~400-row) table keeps the page within ~90s of chain.
     const marketQ = useQuery(MARKET_STATS_QUERY, {
         client: choiceClient,
         fetchPolicy: 'cache-and-network',
-        pollInterval: 120_000,
+        pollInterval: 30_000,
         errorPolicy: 'all',
     });
     const holdersQ = useQuery(HOLDER_COUNTS_QUERY, {

--- a/src/views/Home/index.tsx
+++ b/src/views/Home/index.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import {
     FaArrowRight,
     FaBullhorn,
+    FaChartLine,
     FaCoins,
     FaDiscord,
     FaFire,
@@ -60,6 +61,7 @@ const FEATURED = [
 
 // Secondary tools — accessible, but a tier below the headline three.
 const MORE_TOOLS = [
+    { to: '/ecosystem', icon: <FaChartLine />, label: 'Ecosystem Explorer' },
     { to: '/manage-tokens', icon: <FaCoins />, label: 'Manage tokens' },
     { to: '/airdrop', icon: <FaParachuteBox />, label: 'Airdrops' },
     { to: '/nft-airdrop', icon: <FaImages />, label: 'NFT drop' },


### PR DESCRIPTION
## What

New **/ecosystem** page: a sortable, filterable comparison table of every token Choice indexes — price, price change, cross-venue **volume**, **unique traders**, **swaps**, liquidity, mcap and **holders**, with the activity columns switchable between **24h / 7d / 30d / 90d**. A more powerful, customizable take on Choice's Explore page.

## Data sources (each degrades independently)

| Column | Source | Live? |
|---|---|---|
| Identity, price, Δ% (all windows), liquidity, mcap | Choice GraphQL `tokens_token` + `analytics_tokenstats` | ✅ now |
| Volume / traders / swaps per window | Choice `analytics_tokenmarketstats` (choice-exchange/choice_exchange_backend#221) | ⏳ after backend deploy — until then the page shows an amber banner and "—" in those columns |
| Holders | trippinj holder tracker (nested `balances_aggregate`), snapshot age in tooltip | ✅ now (tracked tokens only) |

All three queries verified against the live endpoints (2,722 tokens / 55 listed; full fetch ≈ 546 KB @ ~1.1s on a 2-min poll).

## UX

- Window pill toggle (24H/7D/30D/90D) drives the Δ%, Vol, Traders, Swaps columns
- Click-to-sort headers, symbol/name/address search, Listed ⇄ All-tokens toggle, min-liquidity dust filter (Any/$100/$1k/$10k)
- Prefs persisted in localStorage; top-300 render cap in all-tokens mode
- Footnote explains both-sides volume attribution and cross-venue trader dedup
- Nav: header links (desktop bar + slide-out) and a Home "More tools" card

## QA before merge (auto-deploys!)

- [ ] `yarn dev` → /ecosystem renders with real data (typecheck ✅, lint clean on new files ✅, `yarn build` ✅)
- [ ] Merge + deploy backend #221 first if you want the volume/traders columns populated on day one (page is safe to ship before it — banner explains the gap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)