### PR TITLE
feat(ecosystem): use the rollup's cross-venue liquidity sum

### DIFF
--- a/src/views/EcosystemExplorer/data.ts
+++ b/src/views/EcosystemExplorer/data.ts
@@ -45,6 +45,7 @@ export const MARKET_STATS_QUERY = gql`
     query EcosystemMarketStats {
         analytics_tokenmarketstats {
             token_id
+            liquidity_usd
             volume_usd_24h
             volume_usd_7d
             volume_usd_30d
@@ -141,6 +142,13 @@ export const buildRows = (
         const row = byAddress.get(m.token_id);
         if (!row) continue;
         row.hasMarketStats = true;
+        // Prefer the rollup's cross-venue liquidity SUM (XYK + CLMM + Mito
+        // vaults, both sides, canonical) — tokenstats' total_liquidity_usd is
+        // only the single most-liquid venue's TVL, which made e.g. SHROOM and
+        // SAI report the identical figure (their shared pool).
+        if (m.liquidity_usd != null) {
+            row.liquidityUsd = Number(m.liquidity_usd) || 0;
+        }
         for (const w of STAT_WINDOWS) {
             const suffix = w;
             row.volume[w] = Number(m[`volume_usd_${suffix}`]) || 0;

--- a/src/views/EcosystemExplorer/index.tsx
+++ b/src/views/EcosystemExplorer/index.tsx
@@ -473,7 +473,9 @@ const EcosystemExplorer = () => {
                         Volume, traders and swaps are unioned across Choice AMM, CLMM and Helix
                         spot orderbook markets. A trade counts toward both sides of its pair, so
                         quote tokens (INJ, USDT…) carry everything traded against them. Traders
-                        are unique wallets, deduplicated across venues. Holder counts come from
+                        are unique wallets, deduplicated across venues. Liquidity is the sum of
+                        every venue the Choice indexer values — XYK pool reserves, CLMM pool TVL
+                        and Mito vaults — also credited to both sides. Holder counts come from
                         the trippy holder tracker and only exist for tokens it has indexed —
                         hover for snapshot age.
                     </p>


### PR DESCRIPTION
The explorer's Liquidity column read `analytics_tokenstats.total_liquidity_usd`, which despite the name is only the **single most-liquid venue's TVL** — SHROOM and SAI showed the identical $11.4k (their shared SHROOM/SAI pool) instead of SHROOM's real **~$24k** across Choice ($15.8k) + Mito ($4.7k) + DojoSwap ($3.6k) + Astroport.

Now prefers `analytics_tokenmarketstats.liquidity_usd` (backend choice-exchange/choice_exchange_backend#223): the sum of every venue's latest USD valuation — XYK reserves, CLMM TVL, **Mito vault TVL** — both sides credited, CW20/wrapper canonically folded, refreshed every minute by the fast lane. Matches the Choice Explore venue-breakdown popover's total. Footnote updated.

**Deploy order**: merge + deploy backend #223 first (`make migrate` + hasura restart). Until then the market-stats query validation-fails as a unit and the page falls back to the old field + amber banner — same graceful degradation as before, nothing breaks.

typecheck ✅ lint (new files) ✅ build ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)