### PR TITLE
fix: iOS blank-screen — stop persisting token/pool lists to localStorage

### DIFF
--- a/src/store/usePoolStore.tsx
+++ b/src/store/usePoolStore.tsx
@@ -1,22 +1,24 @@
 import { create } from 'zustand';
-import { persist } from 'zustand/middleware';
 import { LiquidityPool } from '../utils/types';
+
+// Deliberately NOT persisted — same reasoning as useTokenStore. The pool list is
+// network-hydrated by PoolInitializer (`network-only`) and grows unbounded as
+// pools are indexed, so persisting it is the same iOS localStorage-quota hazard
+// that white-screens the app. Clear any stale key from older builds.
+try {
+    localStorage.removeItem('pools-storage');
+} catch {
+    /* storage blocked (private mode) — nothing to clean up */
+}
 
 export interface PoolStore {
     pools: LiquidityPool[];
     setPools: (pools: LiquidityPool[]) => void;
 }
 
-const useLiquidityPoolStore = create<PoolStore>()(
-    persist(
-        (set) => ({
-            pools: [],
-            setPools: (pools: LiquidityPool[]) => set({ pools }),
-        }),
-        {
-            name: 'pools-storage',
-        }
-    )
-);
+const useLiquidityPoolStore = create<PoolStore>()((set) => ({
+    pools: [],
+    setPools: (pools: LiquidityPool[]) => set({ pools }),
+}));
 
 export default useLiquidityPoolStore;

--- a/src/store/useTokenStore.tsx
+++ b/src/store/useTokenStore.tsx
@@ -1,22 +1,28 @@
 import { create } from 'zustand';
-import { persist } from 'zustand/middleware';
 import { Token } from '../utils/types';
+
+// Deliberately NOT persisted. The full token list (2700+ tokens, each carrying
+// nested pool/price graphs) serializes to ~5–8MB, which overflows iOS Safari's
+// ~5MB localStorage quota: the persist write throws QuotaExceededError and, being
+// uncaught, crashes the whole app before React mounts — a blank page on every
+// iPhone browser. TokenInitializer refetches the list `network-only` on load
+// (and every 100s), so persistence bought a marginally faster first paint at the
+// cost of an app-wide outage. Drop any stale key older builds left behind so
+// affected users reclaim their quota.
+try {
+    localStorage.removeItem('tokens-storage');
+} catch {
+    /* storage blocked (private mode) — nothing to clean up */
+}
 
 export interface TokenStore {
     tokens: Token[];
     setTokens: (tokens: Token[]) => void;
 }
 
-const useTokenStore = create<TokenStore>()(
-    persist(
-        (set) => ({
-            tokens: [],
-            setTokens: (tokens: Token[]) => set({ tokens }),
-        }),
-        {
-            name: 'tokens-storage',
-        }
-    )
-);
+const useTokenStore = create<TokenStore>()((set) => ({
+    tokens: [],
+    setTokens: (tokens: Token[]) => set({ tokens }),
+}));
 
 export default useTokenStore;

--- a/src/store/useWalletStore.tsx
+++ b/src/store/useWalletStore.tsx
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
+import { safeJSONStorage } from '../utils/safeStorage';
 
 export interface WalletStore {
 
@@ -31,6 +32,9 @@ const useWalletStore = create<WalletStore>()(
         }),
         {
             name: 'wallet-storage',
+            // Small, but route through the crash-safe storage so a full/blocked
+            // localStorage can never white-screen the app on write.
+            storage: safeJSONStorage,
         }
     )
 );

--- a/src/utils/safeStorage.ts
+++ b/src/utils/safeStorage.ts
@@ -1,0 +1,31 @@
+import { createJSONStorage } from 'zustand/middleware';
+
+// A JSON storage for zustand `persist` that can never crash the app. iOS Safari
+// caps localStorage at ~5MB per origin and throws QuotaExceededError on an
+// over-quota write; left unhandled that error bubbles through React's render and
+// white-screens the whole app on every iPhone browser. Here we swallow it — the
+// value simply isn't persisted this time — so the app keeps running. Also
+// tolerates private-mode SecurityError.
+export const safeJSONStorage = createJSONStorage(() => ({
+    getItem: (name: string): string | null => {
+        try {
+            return localStorage.getItem(name);
+        } catch {
+            return null;
+        }
+    },
+    setItem: (name: string, value: string): void => {
+        try {
+            localStorage.setItem(name, value);
+        } catch (e) {
+            console.warn(`[safeStorage] could not persist "${name}"`, e);
+        }
+    },
+    removeItem: (name: string): void => {
+        try {
+            localStorage.removeItem(name);
+        } catch {
+            /* ignore */
+        }
+    },
+}));


### PR DESCRIPTION
## Summary

**The whole app currently white-screens on every iPhone browser** (not just `/ecosystem` — that's just where reports surfaced). Root cause is an app-wide `localStorage` quota overflow.

`TokenInitializer` / `PoolInitializer` mount above the router and persist the **full** token and pool lists (with nested pool/price graphs) into `localStorage` via zustand `persist`. The token payload is currently ~2,700 tokens → **~5.6–8.3 MB** serialized. iOS Safari caps `localStorage` at ~5 MB per origin and throws `QuotaExceededError` on the over-quota write; uncaught, it bubbles through React's initial render and crashes the app **before it mounts**. Desktop Chrome's larger quota masked it. Both lists are refetched `network-only` on load anyway, so persistence bought at most a marginally faster first paint.

## Changes

- **`useTokenStore` / `usePoolStore`** — drop `persist` (both are network-hydrated). Each clears any stale `tokens-storage` / `pools-storage` key on load so already-affected users reclaim their quota.
- **`src/utils/safeStorage.ts`** (new) — a `createJSONStorage` wrapper whose `setItem` swallows `QuotaExceededError`, so no persisted store can white-screen the app again.
- **`useWalletStore`** — keeps `persist` (wallet selection must survive reloads) but routed through the crash-safe storage.

## Verification (WebKit — same engine as all iOS browsers)

- **Before:** home and `/ecosystem` → `root` has 0 children, uncaught `QuotaExceededError`, blank page.
- **After:** both mount (`rootChildCount: 5`), `/ecosystem` renders rows, `0` quota errors, only the 0.2 KB prefs key remains in `localStorage`.
- **Existing-user case:** seeded a stale 2 MB `tokens-storage` → auto-removed on boot, app mounts.
- `tsc --noEmit` and `eslint` clean.

## Notes

- This is independent of the Ecosystem Explorer feature (PR #153) — it only touches the shared stores, so it can ship immediately.
- Unrelated: the ecosystem page's windowed volume/trader columns still depend on backend #221; until that deploys they degrade gracefully (amber banner). Not affected by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)