### PR TITLE
Redesign Airdrop History page and cards

### DIFF
--- a/src/components/App/AIrdropCord.tsx
+++ b/src/components/App/AIrdropCord.tsx
@@ -1,12 +1,12 @@
-import { useRef } from "react";
+import { useRef, useState } from "react";
 import dayjs from "dayjs";
-import { PiParachute } from "react-icons/pi";
+import { PiParachuteBold, PiUsersThreeBold, PiCoinsBold } from "react-icons/pi";
+import { FiCopy, FiCheck, FiExternalLink } from "react-icons/fi";
 import { toPng } from "html-to-image";
-import shroomi from "../../assets/mush_sticker.png";
 import shroomlogo from "../../assets/shroom.jpg";
 
 import useTokenStore from "../../store/useTokenStore";
-import { humanReadableAmount } from "../../utils/format";
+import { humanReadableAmount, shortAddress } from "../../utils/format";
 
 type Props = {
     log: {
@@ -22,116 +22,202 @@ type Props = {
     };
 };
 
+// Snapshot criteria/descriptions embed raw ISO timestamps
+// (e.g. "HOLDERS OF SACKS NFTS AT 2025-11-07T18:20:52.763Z"). Swap any ISO
+// datetime for a human-friendly rendering so the copy reads cleanly.
+const ISO_RE = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z?/g;
+const prettifyTimestamps = (text: string) =>
+    (text ?? "").replace(ISO_RE, (m) => dayjs(m).format("MMM D, YYYY · HH:mm"));
+
 const AirdropCard = ({ log }: Props) => {
     const cardRef = useRef<HTMLDivElement>(null);
+    const [copied, setCopied] = useState(false);
 
-    const { tokens } = useTokenStore()
+    const { tokens } = useTokenStore();
+    const tokenDetails = tokens.find(
+        (token) => token.address == (log.token as any).address,
+    );
 
-    const tokenDetails = tokens.find(token => token.address == (log.token as any).address)
+    const symbol = log.token?.symbol?.trim();
+    const hashes = (log.tx_hashes ?? "").split(",").map((h) => h.trim()).filter(Boolean);
 
     const copyPng = async () => {
         if (!cardRef.current) return;
-
         const dataUrl = await toPng(cardRef.current, {
             pixelRatio: 2,
             filter: (node) =>
                 !(node.classList && node.classList.contains("no-export")),
         });
-
         const blob = await (await fetch(dataUrl)).blob();
         await navigator.clipboard.write([
             new ClipboardItem({ "image/png": blob }),
         ]);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 1600);
     };
 
     return (
-        <div
+        <article
             ref={cardRef}
             className="
-        relative overflow-hidden rounded-2xl p-4 mb-6 text-sm
-        bg-[#002B3D]
-        shadow-lg ring-1 ring-white/10 backdrop-blur-md
-        transition hover:scale-[1.02] hover:shadow-2xl
-      "
+                group relative overflow-hidden rounded-2xl mb-5
+                bg-linear-to-b from-[#04262f] to-[#00151d]
+                ring-1 ring-white/10 shadow-lg
+                transition duration-200 hover:ring-white/20 hover:shadow-2xl
+            "
         >
-            {tokenDetails && (
+            {/* faint, corner-masked token watermark — decorative, keeps text readable */}
+            {tokenDetails?.icon && (
                 <img
                     src={tokenDetails.icon}
-                    alt={`${tokenDetails.symbol} logo`}
+                    alt=""
+                    aria-hidden
                     className="
-                        absolute inset-0
-                        w-full h-full object-contain
-                        opacity-20
-                        pointer-events-none
-                        select-none
+                        pointer-events-none select-none absolute -right-8 -top-8
+                        h-40 w-40 rounded-full object-cover opacity-[0.06] blur-[1px]
+                        mask-[radial-gradient(circle_at_center,black,transparent_70%)]
                     "
                 />
             )}
-            {/* floating shroomi */}
-            <img
-                src={shroomi}
-                alt="Shroomi"
-                className="absolute w-28 right-3 top-2 drop-shadow-lg select-none pointer-events-none"
-            />
 
-            <button
-                onClick={() => { void copyPng(); }}
-                className="no-export absolute top-40 right-2 flex items-center gap-1
-                   rounded-md bg-white/10 hover:bg-white/20 px-2 py-1
-                   text-[11px] font-medium backdrop-blur-sm"
-            >
-                {/* <ClipboardIcon className="w-4 h-4" /> */}
-                Copy img
-            </button>
+            {/* accent top hairline */}
+            <div className="absolute inset-x-0 top-0 h-px bg-linear-to-r from-transparent via-trippyYellow/40 to-transparent" />
 
+            <div className="relative p-5">
+                {/* header */}
+                <div className="flex items-start gap-3">
+                    {tokenDetails?.icon ? (
+                        <img
+                            src={tokenDetails.icon}
+                            alt={symbol ? `${symbol} logo` : "token"}
+                            className="h-11 w-11 shrink-0 rounded-full object-cover ring-2 ring-white/15"
+                        />
+                    ) : (
+                        <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-white/5 ring-2 ring-white/10">
+                            <PiParachuteBold className="text-xl text-trippyYellow/80" />
+                        </div>
+                    )}
 
+                    <div className="min-w-0 flex-1">
+                        <h3 className="truncate text-base font-semibold text-white">
+                            Airdropped {symbol ? `${symbol} ` : ""}
+                            <span className="text-slate-300">
+                                to {log.total_participants} wallets
+                            </span>
+                        </h3>
+                        <p className="mt-0.5 text-xs text-slate-400">
+                            {dayjs(log.time).fromNow()}
+                            <span className="mx-1.5 text-slate-600">·</span>
+                            {dayjs(log.time).format("MMM D, YYYY")}
+                        </p>
+                    </div>
 
-            <div className="flex items-center text-indigo-100 mb-1 text-xl font-bold">
-                <PiParachute className="mr-2 text-xl" />
-                <p className="text-lg">Airdropped {log.token.symbol} to {log.total_participants} wallets</p>
-                {/* {tokenDetails && <img
-                    src={tokenDetails.icon} />
-                } */}
-            </div>
-
-            <a
-                href={`https://explorer.injective.network/account/${log.wallet.address}`}
-                className="block text-sm mb-2 hover:text-indigo-400"
-            >
-                By wallet:&nbsp;
-                <span className="font-mono">
-                    {log.wallet.address.slice(0, 8)}…{log.wallet.address.slice(-8)}
-                </span>
-
-            </a>
-
-            <p>Time: {dayjs(log.time).fromNow()}</p>
-
-            <p className="mt-2 whitespace-pre-line text-lg font-semibold">
-                {log.criteria.toLocaleUpperCase()}
-                <br />
-                {log.description.toLocaleUpperCase()}
-            </p>
-
-            <div className="mt-2">
-                <b>TX hashes:</b>
-                {log.tx_hashes.split(",").map((hash, i) => (
-                    <a
-                        key={i}
-                        href={`https://explorer.injective.network/transaction/${hash}`}
-                        className="block text-indigo-100 hover:text-indigo-400 text-xs"
+                    <button
+                        onClick={() => { void copyPng(); }}
+                        title="Copy card as image"
+                        className="no-export flex shrink-0 items-center gap-1.5 rounded-lg
+                            bg-white/5 px-2.5 py-1.5 text-[11px] font-medium text-slate-300
+                            ring-1 ring-white/10 transition hover:bg-white/10 hover:text-white"
                     >
-                        explorer.injective.network/…/{hash.slice(0, 6)}…
-                    </a>
-                ))}
-            </div>
+                        {copied ? (
+                            <><FiCheck className="text-emerald-400" /> Copied</>
+                        ) : (
+                            <><FiCopy /> Copy img</>
+                        )}
+                    </button>
+                </div>
 
-            <div className="text-right mt-3 text-sm flex flex-row items-center justify-end">
-                fee: {humanReadableAmount(log.fee)} SHROOM
-                <img src={shroomlogo} className="w-8 rounded-full ml-2" />
+                {/* description / criteria */}
+                <div className="mt-4 space-y-1.5">
+                    {log.description && (
+                        <p className="text-sm font-medium leading-relaxed text-slate-100">
+                            {prettifyTimestamps(log.description)}
+                        </p>
+                    )}
+                    {log.criteria && (
+                        <p className="text-xs leading-relaxed text-slate-400">
+                            {prettifyTimestamps(log.criteria)}
+                        </p>
+                    )}
+                </div>
+
+                {/* stat strip */}
+                <div className="mt-4 grid grid-cols-3 gap-2">
+                    <Stat
+                        icon={<PiUsersThreeBold />}
+                        label="Recipients"
+                        value={log.total_participants.toLocaleString()}
+                    />
+                    <Stat
+                        icon={<PiParachuteBold />}
+                        label="Amount"
+                        value={`${humanReadableAmount(log.amount_dropped)}${symbol ? ` ${symbol}` : ""}`}
+                    />
+                    <Stat
+                        icon={<PiCoinsBold />}
+                        label="Fee"
+                        value={
+                            <span className="inline-flex items-center gap-1">
+                                {humanReadableAmount(log.fee)} SHROOM
+                                <img src={shroomlogo} alt="" className="h-3.5 w-3.5 rounded-full" />
+                            </span>
+                        }
+                    />
+                </div>
+
+                {/* footer: sender + tx links */}
+                <div className="mt-4 flex flex-wrap items-center gap-2 border-t border-white/5 pt-3">
+                    <a
+                        href={`https://explorer.injective.network/account/${log.wallet.address}`}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="inline-flex items-center gap-1.5 rounded-md bg-white/5 px-2 py-1
+                            font-mono text-[11px] text-slate-300 ring-1 ring-white/10
+                            transition hover:text-white hover:ring-white/20"
+                    >
+                        {shortAddress(log.wallet.address)}
+                        <FiExternalLink className="text-slate-500" />
+                    </a>
+
+                    <span className="ml-auto text-[10px] uppercase tracking-wide text-slate-500">
+                        {hashes.length} tx
+                    </span>
+                    {hashes.map((hash, i) => (
+                        <a
+                            key={i}
+                            href={`https://explorer.injective.network/transaction/${hash}`}
+                            target="_blank"
+                            rel="noreferrer"
+                            className="inline-flex items-center gap-1 rounded-md bg-trippyYellow/10 px-2 py-1
+                                font-mono text-[11px] text-trippyYellow/90 ring-1 ring-trippyYellow/20
+                                transition hover:bg-trippyYellow/20"
+                        >
+                            {hash.slice(0, 6)}…{hash.slice(-4)}
+                            <FiExternalLink className="opacity-70" />
+                        </a>
+                    ))}
+                </div>
             </div>
-        </div>
+        </article>
     );
 };
+
+const Stat = ({
+    icon,
+    label,
+    value,
+}: {
+    icon: React.ReactNode;
+    label: string;
+    value: React.ReactNode;
+}) => (
+    <div className="rounded-xl bg-black/20 px-3 py-2 ring-1 ring-white/5">
+        <div className="flex items-center gap-1 text-[10px] uppercase tracking-wide text-slate-500">
+            <span className="text-slate-400">{icon}</span>
+            {label}
+        </div>
+        <div className="mt-0.5 truncate text-sm font-semibold text-white">{value}</div>
+    </div>
+);
 
 export default AirdropCard;

--- a/src/views/AirdropHistory/index.tsx
+++ b/src/views/AirdropHistory/index.tsx
@@ -1,5 +1,7 @@
 import { Link } from "react-router-dom";
 import { useEffect, useState } from "react";
+import { PiParachuteBold } from "react-icons/pi";
+import { FiPlus } from "react-icons/fi";
 import ShroomBalance from "../../components/App/ShroomBalance";
 import { gql, useQuery } from '@apollo/client';
 import Footer from "../../components/App/Footer";
@@ -34,76 +36,98 @@ query getAirdropHistory {
 const AirdropHistory = () => {
     const { networkKey: currentNetwork } = useNetworkStore()
 
-    const { data } = useQuery(AIRDROP_HISTORY_QUERY, {
+    const { data, loading } = useQuery(AIRDROP_HISTORY_QUERY, {
         fetchPolicy: "network-only",
         pollInterval: 5000
     })
 
-    const [airdropData, setAirdropData] = useState([])
+    const [airdropData, setAirdropData] = useState<any[]>([])
 
     useEffect(() => {
         if (!data) return
         setAirdropData(data.airdrop_tracker_airdroplog)
     }, [data])
 
+    const totalWallets = airdropData.reduce(
+        (sum, log) => sum + (Number(log.total_participants) || 0),
+        0,
+    )
 
     return (
-        <div className="flex flex-col min-h-screen pb-10 bg-customGray">
-
-            <div className="pt-16 mx-2 pb-20">
-                {currentNetwork == "mainnet" && <div className="mt-2 md:mt-0"><ShroomBalance /></div>}
-
-                <div className="min-h-full mt-2 md:mt-0 lg:w-1/2 mx-auto">
-                    <div className="px-2 text-white">
-
-                        <div className="text-white text-2xl font-magic">Airdrop History</div>
-                        <div className="flex flex-row justify-end mb-5">
-                            <Link to="/airdrop" className="bg-slate-800 p-2 mt-2 rounded-sm  text-sm">
-                                Do airdrop
-                            </Link>
-                        </div>
-
-                        {airdropData.length > 0 && airdropData.map((log, index) => {
-                            // return <div className="my-2 bg-slate-800 p-4 rounded-lg text-sm" key={index}>
-
-                            //     <div className="flex flex-row items-center">
-                            //         <PiParachute className="mr-2 text-2xl" />
-                            //         {dayjs(value.time).fromNow()}
-
-                            //     </div>
-                            //     <a
-                            //         href={`https://explorer.injective.network/account/${value.wallet.address}`}
-                            //     >
-                            //         performed by wallet: <span className="text-indigo-300 hover:text-indigo-900">{value.wallet.address.slice(0, 8)}...{value.wallet.address.slice(-8)}</span>
-                            //     </a>
-                            //     <div className="text-lg"><b>token dropped:</b> {value.token.symbol}</div>
-                            //     <div className="text-lg"><b>participants:</b> {value.total_participants}</div>
-
-                            //     <div className="text-lg">{value.criteria}
-                            //         <br />
-                            //         {value.description}
-                            //     </div>
-                            //     TX hashes:
-                            //     {value.tx_hashes.split(",").map((value, index) => {
-                            //         return <a
-                            //             key={index}
-                            //             className="hover:text-indigo-900 text-indigo-300"
-                            //             href={`https://explorer.injective.network/transaction/${value}`}
-                            //         >
-                            //             <div className="text-sm" key={index}>
-                            //                 explorer.injective.network/transaction/{value.slice(0, 5)}...
-                            //             </div>
-                            //         </a>
-
-                            //     })}
-                            //     <div className="text-sm flex flex-row justify-end mt-2">fee: {humanReadableAmount(value.fee)} SHROOM</div>
-                            // </div>
-                            return (
-                                <AirdropCard key={index} log={log} />
-                            )
-                        })}
+        <div className="flex min-h-screen flex-col bg-customGray">
+            <div className="mx-auto w-full max-w-3xl flex-1 px-4 pt-20 pb-16">
+                {currentNetwork == "mainnet" && (
+                    <div className="mb-6 flex justify-end">
+                        <ShroomBalance />
                     </div>
-                </div>
+                )}
+
+                {/* page header */}
+                <header className="mb-6 flex flex-col gap-4 border-b border-white/10 pb-5 sm:flex-row sm:items-end sm:justify-between">
+                    <div>
+                        <div className="flex items-center gap-2 text-trippyYellow/90">
+                            <PiParachuteBold className="text-xl" />
+                            <span className="text-[11px] font-medium uppercase tracking-[0.2em] text-slate-400">
+                                On-chain record
+                            </span>
+                        </div>
+                        <h1 className="mt-1 font-magic text-3xl font-bold text-white">
+                            Airdrop History
+                        </h1>
+                        <p className="mt-1 text-sm text-slate-400">
+                            {airdropData.length > 0 ? (
+                                <>
+                                    {airdropData.length.toLocaleString()} airdrops ·{" "}
+                                    {totalWallets.toLocaleString()} wallets rewarded
+                                </>
+                            ) : (
+                                "Every airdrop sent through Trippy Tools"
+                            )}
+                        </p>
+                    </div>
+
+                    <Link
+                        to="/airdrop"
+                        className="inline-flex items-center justify-center gap-2 rounded-lg
+                            bg-trippyYellow px-5 py-2.5 text-sm font-bold text-black
+                            shadow-lg shadow-trippyYellow/10 transition hover:brightness-110"
+                    >
+                        <FiPlus className="text-base" />
+                        Do airdrop
+                    </Link>
+                </header>
+
+                {/* content */}
+                {loading && airdropData.length === 0 ? (
+                    <div className="space-y-5">
+                        {Array.from({ length: 3 }).map((_, i) => (
+                            <div
+                                key={i}
+                                className="h-52 animate-pulse rounded-2xl bg-white/5 ring-1 ring-white/10"
+                            />
+                        ))}
+                    </div>
+                ) : airdropData.length === 0 ? (
+                    <div className="flex flex-col items-center justify-center rounded-2xl border border-dashed border-white/10 bg-white/2 py-16 text-center">
+                        <PiParachuteBold className="text-4xl text-slate-600" />
+                        <p className="mt-3 text-sm font-medium text-slate-300">
+                            No airdrops yet
+                        </p>
+                        <p className="mt-1 text-xs text-slate-500">
+                            Be the first to reward your community.
+                        </p>
+                        <Link
+                            to="/airdrop"
+                            className="mt-4 rounded-lg bg-trippyYellow px-4 py-2 text-sm font-bold text-black transition hover:brightness-110"
+                        >
+                            Do airdrop
+                        </Link>
+                    </div>
+                ) : (
+                    airdropData.map((log, index) => (
+                        <AirdropCard key={log.id ?? index} log={log} />
+                    ))
+                )}
             </div>
 
             <Footer />


### PR DESCRIPTION
Reworks the **Airdrop History** view and `AirdropCard` for a cleaner, more professional look. Verified with `vite build` + `tsc --noEmit` (0 errors) and QA'd locally on the dev server.

### Card (`AIrdropCord.tsx`)
- **Removed** the Shroomi sticker and the full-bleed `opacity-20` token watermark that fought text legibility — replaced with a subtle corner-masked, blurred token watermark (~6%).
- Restructured into a clear top-to-bottom layout:
  - **Header**: circular token avatar (parachute fallback) + title + relative/absolute time.
  - **Body**: description primary, criteria muted, **no more forced ALL-CAPS**, and embedded ISO timestamps prettified (`2025-11-07T18:20:52.763Z` → `Nov 7, 2025 · 18:20`).
  - **Stat strip**: Recipients / Amount / Fee tiles.
  - **Footer**: sender wallet chip + tx-hash pills, all as external explorer links.
- Moved **Copy img** to a ghost icon button with a copied-confirmation; replaced the jumpy `hover:scale` with a hover ring.

### Page (`AirdropHistory/index.tsx`)
- Wider centered container (`max-w-3xl`), header with eyebrow + `font-magic` title + live summary line ("N airdrops · M wallets rewarded"), and a primary `trippyYellow` **Do airdrop** CTA.
- Added **loading skeletons** and an **empty state**; keyed the list on `log.id`; removed the large commented-out dead block.

Only these two files are touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)