### PR TITLE
fix(airdrop-history): show friendly SHROOM symbol/logo on airdrop cards

### DIFF
--- a/src/components/App/AIrdropCord.tsx
+++ b/src/components/App/AIrdropCord.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import dayjs from "dayjs";
 import { PiParachuteBold, PiUsersThreeBold, PiCoinsBold } from "react-icons/pi";
 import { FiCopy, FiCheck, FiExternalLink } from "react-icons/fi";
@@ -7,6 +7,7 @@ import shroomlogo from "../../assets/shroom.jpg";
 
 import useTokenStore from "../../store/useTokenStore";
 import { humanReadableAmount, shortAddress } from "../../utils/format";
+import { fetchShroomTokenMetaCached } from "../../modules/shroomTokenMeta";
 
 type Props = {
     log: {
@@ -16,7 +17,7 @@ type Props = {
         time: string;
         fee: string;
         tx_hashes: string;
-        token: { symbol: string };
+        token: { address?: string; symbol: string };
         total_participants: number;
         wallet: { address: string };
     };
@@ -34,11 +35,31 @@ const AirdropCard = ({ log }: Props) => {
     const [copied, setCopied] = useState(false);
 
     const { tokens } = useTokenStore();
-    const tokenDetails = tokens.find(
-        (token) => token.address == (log.token as any).address,
-    );
+    const denom = log.token?.address;
+    const tokenDetails = tokens.find((token) => token.address == denom);
 
-    const symbol = log.token?.symbol?.trim();
+    // SHROOM launchpad tokens carry the raw subdenom as their on-chain bank
+    // symbol (e.g. "SHROOM_11_273EE1EA53ABBCAD"); the friendly name/symbol/logo
+    // live in the launch's off-chain metadata. Resolve them best-effort so the
+    // card reads "Airdropped BERB" instead of the opaque denom. Falls back to the
+    // raw symbol for non-SHROOM tokens or when the read fails.
+    const [shroomSymbol, setShroomSymbol] = useState<string>();
+    const [shroomImage, setShroomImage] = useState<string>();
+    useEffect(() => {
+        if (!denom) return;
+        let alive = true;
+        void fetchShroomTokenMetaCached(denom).then((meta) => {
+            if (!alive || !meta) return;
+            if (meta.symbol) setShroomSymbol(meta.symbol);
+            if (meta.image) setShroomImage(meta.image);
+        });
+        return () => {
+            alive = false;
+        };
+    }, [denom]);
+
+    const symbol = (shroomSymbol ?? log.token?.symbol)?.trim();
+    const iconUrl = tokenDetails?.icon || shroomImage;
     const hashes = (log.tx_hashes ?? "").split(",").map((h) => h.trim()).filter(Boolean);
 
     const copyPng = async () => {
@@ -67,9 +88,9 @@ const AirdropCard = ({ log }: Props) => {
             "
         >
             {/* faint, corner-masked token watermark — decorative, keeps text readable */}
-            {tokenDetails?.icon && (
+            {iconUrl && (
                 <img
-                    src={tokenDetails.icon}
+                    src={iconUrl}
                     alt=""
                     aria-hidden
                     className="
@@ -86,9 +107,9 @@ const AirdropCard = ({ log }: Props) => {
             <div className="relative p-5">
                 {/* header */}
                 <div className="flex items-start gap-3">
-                    {tokenDetails?.icon ? (
+                    {iconUrl ? (
                         <img
-                            src={tokenDetails.icon}
+                            src={iconUrl}
                             alt={symbol ? `${symbol} logo` : "token"}
                             className="h-11 w-11 shrink-0 rounded-full object-cover ring-2 ring-white/15"
                         />

--- a/src/modules/shroomTokenMeta.ts
+++ b/src/modules/shroomTokenMeta.ts
@@ -177,6 +177,34 @@ export async function fetchShroomTokenMeta(denom: string): Promise<ShroomTokenMe
     return decodeMetadataUri(uri);
 }
 
+// Session cache for the cached wrapper below. Launch metadata is immutable per
+// denom, so a successful resolution is cached for good; a definitive "not a
+// SHROOM denom" (parse fails) is also cached. Transient RPC failures are NOT
+// cached — they resolve to null without a cache entry so a later render retries.
+const shroomMetaCache = new Map<string, ShroomTokenMeta | null>();
+const shroomMetaInflight = new Map<string, Promise<ShroomTokenMeta | null>>();
+
+/// Cached, dedup'd variant of `fetchShroomTokenMeta`. Safe to call from every
+/// row of a list (e.g. the airdrop-history feed): concurrent calls for the same
+/// denom share one in-flight request, and resolved results are memoized for the
+/// session so re-renders don't re-hit the RPC.
+export function fetchShroomTokenMetaCached(denom: string): Promise<ShroomTokenMeta | null> {
+    if (shroomMetaCache.has(denom)) return Promise.resolve(shroomMetaCache.get(denom) ?? null);
+    const inflight = shroomMetaInflight.get(denom);
+    if (inflight) return inflight;
+    const p = (async () => {
+        if (!parseShroomDenom(denom)) {
+            shroomMetaCache.set(denom, null); // definitively not SHROOM — cache the miss
+            return null;
+        }
+        const meta = await fetchShroomTokenMeta(denom);
+        if (meta) shroomMetaCache.set(denom, meta); // only cache successes; let failures retry
+        return meta;
+    })().finally(() => shroomMetaInflight.delete(denom));
+    shroomMetaInflight.set(denom, p);
+    return p;
+}
+
 /// Overlay SHROOM friendly name/symbol/logo/description onto a raw bank-metadata
 /// object (as returned by `TokenUtils.getDenomExtraMetadata`), leaving
 /// decimals / total_supply / admin untouched so downstream amount math is


### PR DESCRIPTION
## Problem

The redesigned airdrop-history cards (PR #158) render the **raw tokenfactory subdenom** as the token symbol for SHROOM launchpad tokens — e.g. *"Airdropped `SHROOM_11_273EE1EA53ABBCAD` to 301 wallets"* and Amount *"30m `SHROOM_11_273EE1EA...`"*. SHROOM tokens keep the raw subdenom as their on-chain bank symbol (v1.20+ locks denom-metadata at mint), so the friendly symbol (`BERB`) only appears in the free-text description, not the title/amount.

<img width="500" alt="before" src="user-reported card showing SHROOM_11_273EE1EA53ABBCAD" />

## Fix

Resolve the launch's off-chain metadata best-effort per card via the existing `fetchShroomTokenMeta` EVM read (`LaunchpadCore.getLaunch(id).metadataURI`), and prefer the friendly symbol + logo:

- **`shroomTokenMeta.ts`** — add `fetchShroomTokenMetaCached`, a session-cached, in-flight-dedup'd wrapper safe to call from every list row (caches successes and definitive non-SHROOM misses; transient RPC failures are not cached so they retry).
- **`AIrdropCord.tsx`** — resolve friendly metadata per card; use `shroomSymbol ?? log.token.symbol` for the title + Amount, and the launch logo for the avatar/watermark when the token store has no entry.

Fully graceful: non-SHROOM tokens and read failures fall back to the raw symbol exactly as today.

Result: *"Airdropped **BERB** to 301 wallets"* / Amount *"30m **BERB**"*, with the real logo.

## Verification

- Confirmed live data: `token.address` = `factory/inj13j2…/shroom_11_273ee1ea53abbcad`, launch 11 → `{name: "canary in a coal mine", symbol: "BERB", image: pinata…}`.
- Exercised the resolver against mainnet EVM RPC → returns `BERB`.
- `tsc --noEmit` ✓ · `eslint` (changed files) ✓ · `vite build` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)