### PR TITLE
Add 5 Talis NFT collections to airdrop + fix MASKED holder-airdrop error

### DIFF
--- a/src/constants/contractAddresses.ts
+++ b/src/constants/contractAddresses.ts
@@ -520,6 +520,37 @@ export const CHOICE_FACTORY = "inj1k9lcqtn3y92h4t3tdsu7z8qx292mhxhgsssmxg";
 // ];
 
 export const NFT_COLLECTIONS = [
+    // Verified on-chain 2026-07-08 (Talis admin inj1maeyvxf… + num_tokens +
+    // owner-spread sampling, and cross-checked against the Talis family→contract
+    // mapping where a family URL was known). The chain has many 1:1 fake copies
+    // with identical names parked in a single wallet — these are the real,
+    // holder-spread contracts.
+    {
+        value: "inj1nxz20pe8d7gsp5yy9vcdfgtq68qmn9rhj23ftd",
+        label: "The InjHallas",
+        img: "https://talis-protocol.mo.cloudinary.net/inj/families/64e6a4e67ed45e3ad0ba4b26/miniaturePicture",
+    },
+    {
+        value: "inj1uq453kp4yda7ruc0axpmd9vzfm0fj62padhe0p",
+        label: "Pedro",
+        img: "https://gateway.pinata.cloud/ipfs/QmYgVA9bxfUq2DbLWingxMZARVv8X9YdeAu34a1iiDLATq/avatar_1539.png",
+    },
+    {
+        value: "inj1d3xuuquv7hf9m0grfehlwacmylqw0njsf4kx5h",
+        label: "Aliens On Injective",
+        img: "https://gateway.pinata.cloud/ipfs/QmXMNKHXcLr33pqWnRHHuHjhgftQ145XjHhh2UuXPFYxbL/1.png",
+    },
+    {
+        value: "inj1vjk598p5hkyjdc4qltjrzgwmhuywvhyaw8fdm0",
+        label: "100 Shades of Berb",
+        img: "https://talis-protocol.mo.cloudinary.net/inj/families/660b145db4aa2ed094b45300/miniaturePicture",
+    },
+    {
+        // "unverified on Talis" (no family miniature) — falls back to token art.
+        value: "inj1axy9hfzzrpuh85dfca44dhyhqyv3wuymq2f9kp",
+        label: "Numbers",
+        img: "https://gateway.pinata.cloud/ipfs/QmTXmUtwMBWvmTLkx6yn71T1pBJparGmytCW4UEKpENmGF",
+    },
     {
         value: "inj19ly43dgrr2vce8h02a8nw0qujwhrzm9yv8d75c",
         label: "The Ninjas",

--- a/src/modules/tokenUtils.tsx
+++ b/src/modules/tokenUtils.tsx
@@ -1298,15 +1298,36 @@ class TokenUtils {
         return ownerResults;
     }
 
-    async getNFTHolders(collectionAddress: string, setProgress: React.Dispatch<React.SetStateAction<string>>) {
-        const numTokensQuery = Buffer.from(
-            JSON.stringify({
-                num_tokens: {}
-            })
-        ).toString("base64");
+    // Smart-query a contract with retry + exponential backoff. Enumerating a
+    // large collection's holders is hundreds of sequential paginated queries
+    // (a 6,666-supply collection = ~223 pages over a couple of minutes); the
+    // public gRPC-web endpoint intermittently rate-limits or drops a request
+    // over such a long run. Without a retry a single blip aborts the whole
+    // airdrop with an error — so every page/count query goes through here.
+    async smartQueryWithRetry(
+        collectionAddress: string,
+        msg: object,
+        retries = 4,
+        delay = 600,
+    ): Promise<any> {
+        const query = Buffer.from(JSON.stringify(msg)).toString("base64");
+        let lastErr: unknown;
+        for (let attempt = 0; attempt <= retries; attempt++) {
+            try {
+                const res = await this.chainGrpcWasmApi.fetchSmartContractState(collectionAddress, query);
+                return JSON.parse(new TextDecoder().decode(res.data));
+            } catch (error) {
+                lastErr = error;
+                if (attempt < retries) {
+                    await new Promise((resolve) => setTimeout(resolve, delay * Math.pow(2, attempt)));
+                }
+            }
+        }
+        throw lastErr;
+    }
 
-        const numTokensInfo = await this.chainGrpcWasmApi.fetchSmartContractState(collectionAddress, numTokensQuery);
-        const numTokensDecoded = JSON.parse(new TextDecoder().decode(numTokensInfo.data));
+    async getNFTHolders(collectionAddress: string, setProgress: React.Dispatch<React.SetStateAction<string>>) {
+        const numTokensDecoded = await this.smartQueryWithRetry(collectionAddress, { num_tokens: {} });
         const totalTokens = numTokensDecoded.count;
         console.log("total NFT tokens", numTokensDecoded);
 
@@ -1315,17 +1336,12 @@ class TokenUtils {
         const holderMap: Record<string, any> = {};
 
         while (hasMore) {
-            const allTokensQuery = Buffer.from(
-                JSON.stringify({
-                    all_tokens: {
-                        start_after: startAfter.length > 0 ? startAfter : null,
-                        limit: 30
-                    }
-                })
-            ).toString("base64");
-
-            const allTokensInfo = await this.chainGrpcWasmApi.fetchSmartContractState(collectionAddress, allTokensQuery);
-            const allTokensDecoded = JSON.parse(new TextDecoder().decode(allTokensInfo.data));
+            const allTokensDecoded = await this.smartQueryWithRetry(collectionAddress, {
+                all_tokens: {
+                    start_after: startAfter.length > 0 ? startAfter : null,
+                    limit: 30,
+                },
+            });
 
             if (allTokensDecoded && allTokensDecoded.tokens && allTokensDecoded.tokens.length > 0) {
                 // Tokens that need an owner lookup


### PR DESCRIPTION
## Collections added (from a user request)

Adds the requested collections to the NFT airdrop picker (`NFT_COLLECTIONS`):

| Collection | Contract | Supply | Talis family |
|---|---|---|---|
| The InjHallas | `inj1nxz20pe8d7gsp5yy9vcdfgtq68qmn9rhj23ftd` | 1050 | `64e6a4e6…` |
| Pedro | `inj1uq453kp4yda7ruc0axpmd9vzfm0fj62padhe0p` | 709 | — |
| Aliens On Injective | `inj1d3xuuquv7hf9m0grfehlwacmylqw0njsf4kx5h` | 2221 | — |
| 100 Shades of Berb | `inj1vjk598p5hkyjdc4qltjrzgwmhuywvhyaw8fdm0` | 98 | `660b145d…` |
| Numbers | `inj1axy9hfzzrpuh85dfca44dhyhqyv3wuymq2f9kp` | 50 | `6503fd45…` |

**Why the care:** the chain is full of 1:1 fakes — dozens of contracts with these exact names, whole supply parked in one wallet. Each contract here was verified on-chain (Talis admin `inj1maeyvxf…` + `num_tokens` + owner-spread sampling), and the two the user gave family URLs for (Numbers, 100 Shades of Berb) were cross-checked against Talis's authoritative family→contract mapping. Notably **The InjHallas** real contract is on code **105** (supply 1050); the same-named code-49 contracts are empty fakes (supply 0–3).

## MASKED holder-airdrop error fix

The user reported an error airdropping to MASKED holders. `getNFTHolders` enumerates `all_tokens` 30 at a time — MASKED (6,666 supply) is **~223 sequential gRPC-web queries over ~2.5 min**, and the page/count queries had **no retry**, so a single transient rate-limit or dropped request aborted the whole airdrop with an error. (Confirmed: the full enumeration succeeds server-side — 223 pages, 502 holders, 0 errors — it's purely the client's fragility over the long run.)

Fix: route the `num_tokens` + `all_tokens` queries through a new `smartQueryWithRetry` (4 retries, exponential backoff), matching the retry the `owner_of` path already had. Helps every large collection, not just MASKED.

## Verification

- Every contract queried live (contract_info / num_tokens / all_tokens shape / owner-spread).
- `tsc --noEmit` ✓ · `eslint` (changed files) ✓ · `vite build` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)