### PR TITLE
Choice sell quote for SHROOM balance + auto-convert bank→CW20 for fees

### DIFF
--- a/src/components/App/ShroomBalance.tsx
+++ b/src/components/App/ShroomBalance.tsx
@@ -1,59 +1,62 @@
 import { useCallback, useEffect, useState } from "react"
-import TokenUtils from "../../modules/tokenUtils";
+import { BigNumber } from "@injectivelabs/utils";
 import shroom from "../../assets/shroom.jpg"
 import { humanReadableAmount } from "../../utils/helpers";
 import useWalletStore from "../../store/useWalletStore";
-import useNetworkStore from "../../store/useNetworkStore";
-
-const SHROOM_PAIR_ADDRESS = "inj1m35kyjuegq7ruwgx787xm53e5wfwu6n5uadurl"
-const SHROOM_TOKEN_ADDRESS = "inj1300xcg9naqy00fujsr9r8alwk7dh65uqu87xm8"
+import { getSwapApi } from "../../utils/swap/SwapApi";
+import {
+    SHROOM_BANK_DENOM,
+    SHROOM_TOKEN_ADDRESS,
+    quoteShroomSellUsd,
+} from "../../utils/shroomFee";
 
 const ShroomBalance = () => {
     const { connectedWallet } = useWalletStore()
-    const { network } = useNetworkStore()
 
     const [loading, setLoading] = useState(false)
-    const [lastLoadedAddress, setLastLoadedAddress] = useState<any>(null)
+    const [lastLoadedAddress, setLastLoadedAddress] = useState<string | null>(null)
 
-    const [balance, setBalance] = useState<any>(null)
-    const [usd, setUsd] = useState<any>(null)
+    const [balance, setBalance] = useState<string | null>(null)
+    const [usd, setUsd] = useState<string | null>(null)
 
     const getBalance = useCallback(async () => {
         if (!connectedWallet) return
-        const module = new TokenUtils(network);
+        // Mark the address as attempted up-front so a failed load doesn't spin
+        // the polling effect; the user can still force a refresh by clicking.
+        setLastLoadedAddress(connectedWallet)
+        const api = getSwapApi();
         try {
-            const [baseAssetPrice, tokenBalance, pairInfo] = await Promise.all([
-                module.getINJPrice(),
-                module.queryTokenForBalance(SHROOM_TOKEN_ADDRESS, connectedWallet),
-                module.getPairInfo(SHROOM_PAIR_ADDRESS)
+            // SHROOM is sellable whether held as CW20 or as its bank
+            // (factory-wrapped) denom — the fee flow auto-converts bank → CW20 —
+            // so count both toward the balance and the sell quote.
+            const [cw20, bank] = await Promise.all([
+                api.queryTokenForBalance(SHROOM_TOKEN_ADDRESS, connectedWallet).catch(() => ({ balance: '0' })),
+                api.getBalanceOfToken(SHROOM_BANK_DENOM, connectedWallet).catch(() => ({ amount: '0' })),
             ]);
-            const normalizedBalance = (tokenBalance.balance / Math.pow(10, 18)).toFixed(2);
-            setBalance(normalizedBalance);
-            const quote = await module.getSellQuoteRouter(pairInfo, tokenBalance.balance);
-            const returnAmount = Number(quote.amount) / Math.pow(10, 18);
-            const totalUsdValue = (returnAmount * baseAssetPrice!).toFixed(2);
-            setUsd(totalUsdValue);
-            setLastLoadedAddress(connectedWallet)
-            return normalizedBalance
+            const totalShroom = new BigNumber(cw20?.balance ?? 0)
+                .plus(bank?.amount ?? 0)
+                .shiftedBy(-18);
+            setBalance(totalShroom.toFixed(2));
+
+            const sellUsd = await quoteShroomSellUsd(totalShroom.toNumber());
+            setUsd(sellUsd === null ? null : sellUsd.toFixed(2));
+            return totalShroom.toFixed(2)
         } catch (error) {
             console.error('Failed to update balance and USD value:', error);
         }
-    }, [connectedWallet, network]);
+    }, [connectedWallet]);
 
     useEffect(() => {
         if (!connectedWallet) return
         if (loading) return
-        if (!balance || !usd || (!lastLoadedAddress || lastLoadedAddress !== connectedWallet)) {
-            setLoading(true)
-            getBalance().then(() => {
-
-            }).catch(e => {
-                console.log(e)
-            }).finally(() => {
-                setLoading(false)
-            })
-        }
-    }, [balance, getBalance, usd, loading, connectedWallet, lastLoadedAddress])
+        if (lastLoadedAddress === connectedWallet) return
+        setLoading(true)
+        getBalance().catch(e => {
+            console.log(e)
+        }).finally(() => {
+            setLoading(false)
+        })
+    }, [loading, connectedWallet, lastLoadedAddress, getBalance])
 
     useEffect(() => {
         setLastLoadedAddress(null)
@@ -68,7 +71,7 @@ const ShroomBalance = () => {
             <div>
                 <img src={shroom} style={{ borderRadius: '50%', width: 32 }} className="mr-2" alt="Spinning Image" />
             </div>
-            {balance ? humanReadableAmount(balance) : "0"}
+            {balance ? humanReadableAmount(Number(balance)) : "0"}
             <br />
             ${usd ? usd : "0"}
         </div>

--- a/src/utils/shroomFee.ts
+++ b/src/utils/shroomFee.ts
@@ -1,0 +1,139 @@
+// Shared SHROOM fee + quote helpers.
+//
+// The site charges a SHROOM fee for several actions (airdrops, whitelisting,
+// mito market-make). SHROOM can be held either as the CW20 token or as its
+// bank (factory-wrapped) denom, so these helpers:
+//   1. quote a sell value via Choice's optimal router, and
+//   2. build the fee messages, auto-converting bank → CW20 when the wallet's
+//      CW20 balance can't cover the fee.
+import { gql } from '@apollo/client';
+import { MsgExecuteContractCompat } from '@injectivelabs/sdk-ts';
+import { BigNumber } from '@injectivelabs/utils';
+import client from './choiceApolloClient';
+import { getSwapApi } from './swap/SwapApi';
+import { createConvertToCw20Message } from './swap/messages';
+import { CW20_ADAPTER_ADDRESS, MAX_HOPS, ROUTE_FIELD, SHROOM_CW20, USDC } from './swap/constants';
+
+export const SHROOM_TOKEN_ADDRESS = SHROOM_CW20;
+export const SHROOM_FEE_COLLECTION_ADDRESS = 'inj1e852m8j47gr3qwa33zr7ygptwnz4tyf7ez4f3d';
+export const SHROOM_BURN_WALLET_ADDRESS = 'inj1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqe2hm49';
+
+// Bank (factory-wrapped) denom the CW20 adapter mints for SHROOM.
+export const SHROOM_BANK_DENOM = `factory/${CW20_ADAPTER_ADDRESS}/${SHROOM_CW20}`;
+
+const SHROOM_DECIMALS = 18;
+
+// Choice backend optimal-route quote. Input `amount` and `est_output_amount`
+// are both human-readable (verified against the live endpoint), so quoting into
+// USDC gives the dollar sell value directly.
+const SELL_QUOTE_QUERY = gql`
+  query ($input_address: String!, $output_address: String!, $amount_in: numeric!, $max_hops: numeric!) {
+    routes: ${ROUTE_FIELD}(asset_in: $input_address, asset_out: $output_address, amount: $amount_in, max_hops: $max_hops) {
+      routes {
+        est_output_amount
+      }
+    }
+  }
+`;
+
+/**
+ * USD value the wallet would receive selling `shroomAmount` (human SHROOM) into
+ * USDC through Choice's best route. USDC is dollar-pegged, so the top route's
+ * estimated output is the USD sell value. Returns 0 for a non-positive amount
+ * and null when Choice finds no route.
+ */
+export async function quoteShroomSellUsd(shroomAmount: number): Promise<number | null> {
+  if (!(shroomAmount > 0)) return 0;
+  try {
+    const { data } = await client.query({
+      query: SELL_QUOTE_QUERY,
+      fetchPolicy: 'no-cache',
+      variables: {
+        input_address: SHROOM_CW20,
+        output_address: USDC,
+        amount_in: String(shroomAmount),
+        max_hops: MAX_HOPS,
+      },
+    });
+    const routes: { est_output_amount?: string | number }[] = data?.routes?.routes ?? [];
+    if (!routes.length) return null;
+    return routes.reduce((best, r) => Math.max(best, Number(r.est_output_amount) || 0), 0);
+  } catch (e) {
+    console.error('shroom sell quote failed', e);
+    return null;
+  }
+}
+
+/**
+ * Ensure the wallet holds at least `requiredCw20Base` (1e18-scaled) CW20 SHROOM,
+ * returning a single convert-from-bank message when the CW20 balance is short
+ * (topping up the shortfall from the wallet's bank/factory-wrapped SHROOM), or
+ * an empty array when no conversion is needed.
+ *
+ * If the CW20 balance can't be read we skip the top-up rather than convert
+ * blindly — redeeming bank tokens the user may not hold would just fail the tx.
+ */
+export async function ensureCw20ShroomMessages(
+  wallet: string,
+  requiredCw20Base: BigNumber.Value,
+): Promise<MsgExecuteContractCompat[]> {
+  const required = new BigNumber(requiredCw20Base);
+  if (!required.isFinite() || required.isLessThanOrEqualTo(0)) return [];
+
+  let held: BigNumber;
+  try {
+    const bal = await getSwapApi().queryTokenForBalance(SHROOM_TOKEN_ADDRESS, wallet);
+    held = new BigNumber(bal?.balance ?? 0);
+  } catch (e) {
+    console.error('shroom cw20 balance lookup failed', e);
+    return [];
+  }
+
+  if (held.isGreaterThanOrEqualTo(required)) return [];
+  const missing = required.minus(held).integerValue(BigNumber.ROUND_CEIL);
+  return [createConvertToCw20Message(SHROOM_BANK_DENOM, missing.toFixed(0), wallet)];
+}
+
+/**
+ * Build the SHROOM fee messages for a whole-token `shroomCost`. When `burn` is
+ * set the fee splits 90% to the collector / 10% to the burn wallet (matching the
+ * airdrop fee); otherwise the full amount goes to the collector. A
+ * convert-from-bank message is prepended when the wallet's CW20 balance can't
+ * cover the fee.
+ */
+export async function buildShroomFeeMessages(
+  wallet: string,
+  shroomCost: number,
+  opts: { burn?: boolean } = {},
+): Promise<MsgExecuteContractCompat[]> {
+  const { burn = false } = opts;
+  const totalBase = new BigNumber(shroomCost).shiftedBy(SHROOM_DECIMALS).integerValue(BigNumber.ROUND_DOWN);
+  if (totalBase.isLessThanOrEqualTo(0)) return [];
+
+  const feeBase = burn ? totalBase.times(0.9).integerValue(BigNumber.ROUND_DOWN) : totalBase;
+  const burnBase = totalBase.minus(feeBase);
+
+  const messages = await ensureCw20ShroomMessages(wallet, totalBase);
+
+  messages.push(
+    MsgExecuteContractCompat.fromJSON({
+      sender: wallet,
+      contractAddress: SHROOM_TOKEN_ADDRESS,
+      msg: { transfer: { recipient: SHROOM_FEE_COLLECTION_ADDRESS, amount: feeBase.toFixed(0) } },
+      funds: [],
+    }),
+  );
+
+  if (burnBase.isGreaterThan(0)) {
+    messages.push(
+      MsgExecuteContractCompat.fromJSON({
+        sender: wallet,
+        contractAddress: SHROOM_TOKEN_ADDRESS,
+        msg: { transfer: { recipient: SHROOM_BURN_WALLET_ADDRESS, amount: burnBase.toFixed(0) } },
+        funds: [],
+      }),
+    );
+  }
+
+  return messages;
+}

--- a/src/views/Airdrop/AirdropConfirmModal.tsx
+++ b/src/views/Airdrop/AirdropConfirmModal.tsx
@@ -1,8 +1,8 @@
 import {
-    MsgExecuteContract,
     MsgExecuteContractCompat,
     MsgMultiSend,
 } from "@injectivelabs/sdk-ts";
+import { buildShroomFeeMessages } from "../../utils/shroomFee";
 import { BigNumberInBase, BigNumberInWei } from "@injectivelabs/utils";
 import { useCallback, useMemo, useState } from "react";
 import { useNavigate } from 'react-router-dom';
@@ -17,10 +17,6 @@ import { performTransaction } from "../../utils/walletStrategy";
 import { CHUNK_SIZE } from "./distribution";
 import { isValidInjAddress } from "./csv";
 import { humanReadableAmount } from "./format";
-
-const SHROOM_TOKEN_ADDRESS = "inj1300xcg9naqy00fujsr9r8alwk7dh65uqu87xm8"
-const FEE_COLLECTION_ADDRESS = "inj1e852m8j47gr3qwa33zr7ygptwnz4tyf7ez4f3d"
-const BURN_WALLET_ADDRESS = "inj1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqe2hm49";
 
 const INSERT_AIRDROP_MUTATION = gql`
 mutation insertAirdropLog (
@@ -269,39 +265,12 @@ const AirdropConfirmModal = (props: {
     }, [connectedAddress, props.tokenDecimals, isPayable]);
 
     const payFee = useCallback(async () => {
-
         const injectiveAddress = connectedAddress as string;
-
-        const totalAmount = props.shroomCost * Math.pow(10, 18);
-        const feeCollectionAmount = (totalAmount * 0.9).toLocaleString('fullwide', { useGrouping: false }); // 90%
-        const burnAmount = (totalAmount * 0.1).toLocaleString('fullwide', { useGrouping: false });          // 10%
-
-        const feeMsg = MsgExecuteContract.fromJSON({
-            contractAddress: SHROOM_TOKEN_ADDRESS,
-            sender: injectiveAddress,
-            msg: {
-                transfer: {
-                    recipient: FEE_COLLECTION_ADDRESS,
-                    amount: feeCollectionAmount,
-                },
-            },
-        });
-
-        const burnMsg = MsgExecuteContract.fromJSON({
-            contractAddress: SHROOM_TOKEN_ADDRESS,
-            sender: injectiveAddress,
-            msg: {
-                transfer: {
-                    recipient: BURN_WALLET_ADDRESS,
-                    amount: burnAmount,
-                },
-            },
-        });
-
-        console.log("send shroom fee", feeMsg);
-        console.log("send shroom burn", burnMsg);
-
-        return await performTransaction(connectedAddress as string, [feeMsg, burnMsg]);
+        // 90% fee / 10% burn, auto-converting bank SHROOM → CW20 if the wallet's
+        // CW20 balance can't cover the fee.
+        const messages = await buildShroomFeeMessages(injectiveAddress, props.shroomCost, { burn: true });
+        console.log("send shroom fee", messages);
+        return await performTransaction(injectiveAddress, messages);
     }, [props.shroomCost, connectedAddress]);
 
     const startAirdrop = useCallback(async () => {

--- a/src/views/DojoWhitelist/index.tsx
+++ b/src/views/DojoWhitelist/index.tsx
@@ -8,9 +8,8 @@ import IPFSImage from "../../components/App/IpfsImage";
 import useWalletStore from "../../store/useWalletStore";
 import useNetworkStore from "../../store/useNetworkStore";
 import { performTransaction } from "../../utils/walletStrategy";
+import { buildShroomFeeMessages } from "../../utils/shroomFee";
 
-const SHROOM_TOKEN_ADDRESS = "inj1300xcg9naqy00fujsr9r8alwk7dh65uqu87xm8"
-const FEE_COLLECTION_ADDRESS = "inj1e852m8j47gr3qwa33zr7ygptwnz4tyf7ez4f3d"
 const SHROOM_PAIR_ADDRESS = "inj1m35kyjuegq7ruwgx787xm53e5wfwu6n5uadurl"
 const DOJO_FACTORY = "inj1pc2vxcmnyzawnwkf03n2ggvt997avtuwagqngk"
 
@@ -86,16 +85,8 @@ const DojoWhitelist = () => {
         }
         setError(null)
 
-        const feeMsg = MsgExecuteContract.fromJSON({
-            contractAddress: SHROOM_TOKEN_ADDRESS,
-            sender: injectiveAddress,
-            msg: {
-                transfer: {
-                    recipient: FEE_COLLECTION_ADDRESS,
-                    amount: (shroomCost).toFixed(0) + "0".repeat(18),
-                },
-            },
-        });
+        // Auto-converts bank SHROOM → CW20 if the wallet's CW20 balance is short.
+        const feeMsgs = await buildShroomFeeMessages(injectiveAddress, shroomCost)
 
         const msgSend = MsgSend.fromJSON({
             amount: {
@@ -124,7 +115,7 @@ const DojoWhitelist = () => {
         const result = await performTransaction(
             injectiveAddress,
             [
-                feeMsg,
+                ...feeMsgs,
                 msgSend,
                 addTokenDecimals
             ]

--- a/src/views/MitoMarketMake/index.tsx
+++ b/src/views/MitoMarketMake/index.tsx
@@ -7,11 +7,10 @@ import { humanReadableAmount } from "../../utils/helpers";
 import useWalletStore from "../../store/useWalletStore";
 import useNetworkStore from "../../store/useNetworkStore";
 import { performTransaction } from "../../utils/walletStrategy";
-import { MsgExecuteContract, MsgExecuteContractCompat } from "@injectivelabs/sdk-ts";
+import { MsgExecuteContractCompat } from "@injectivelabs/sdk-ts";
 import { toast } from 'react-toastify';
+import { buildShroomFeeMessages } from "../../utils/shroomFee";
 
-const SHROOM_TOKEN_ADDRESS = "inj1300xcg9naqy00fujsr9r8alwk7dh65uqu87xm8"
-const FEE_COLLECTION_ADDRESS = "inj1e852m8j47gr3qwa33zr7ygptwnz4tyf7ez4f3d"
 const SHROOM_PAIR_ADDRESS = "inj1m35kyjuegq7ruwgx787xm53e5wfwu6n5uadurl"
 
 const MitoMarketMake = () => {
@@ -114,32 +113,24 @@ const MitoMarketMake = () => {
         const address = selectedVault.value.matchingVault.contractAddress
         console.log(`send market make for vault ${address}`)
 
-        const injectiveAddress = connectedAddress
+        const injectiveAddress = connectedAddress as string
 
-        const feeMsg = MsgExecuteContract.fromJSON({
-            contractAddress: SHROOM_TOKEN_ADDRESS,
-            sender: injectiveAddress as string,
-            msg: {
-                transfer: {
-                    recipient: FEE_COLLECTION_ADDRESS,
-                    amount: (shroomCost).toFixed(0) + "0".repeat(18),
-                },
-            },
-        });
+        // Auto-converts bank SHROOM → CW20 if the wallet's CW20 balance is short.
+        const feeMsgs = await buildShroomFeeMessages(injectiveAddress, shroomCost)
 
         const msgMarketMake = MsgExecuteContractCompat.fromJSON({
-            sender: injectiveAddress as string,
+            sender: injectiveAddress,
             contractAddress: address,
             msg: {
                 market_make: {}
             },
         });
-        console.log(feeMsg, msgMarketMake)
+        console.log(feeMsgs, msgMarketMake)
 
         const response = await performTransaction(
-            injectiveAddress as string,
+            injectiveAddress,
             [
-                feeMsg,
+                ...feeMsgs,
                 msgMarketMake
             ]
         )

--- a/src/views/NftAirdrop/NftAirdropConfirmModal.tsx
+++ b/src/views/NftAirdrop/NftAirdropConfirmModal.tsx
@@ -1,4 +1,4 @@
-import { MsgExecuteContract, MsgExecuteContractCompat } from "@injectivelabs/sdk-ts";
+import { MsgExecuteContractCompat } from "@injectivelabs/sdk-ts";
 import { useCallback, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { CircleLoader } from "react-spinners";
@@ -9,11 +9,8 @@ import useWalletStore from "../../store/useWalletStore";
 import useNetworkStore from "../../store/useNetworkStore";
 import { performTransaction } from "../../utils/walletStrategy";
 import { isValidInjAddress } from "./csv";
+import { buildShroomFeeMessages } from "../../utils/shroomFee";
 import type { NftPair } from "./types";
-
-const SHROOM_TOKEN_ADDRESS = "inj1300xcg9naqy00fujsr9r8alwk7dh65uqu87xm8";
-const FEE_COLLECTION_ADDRESS = "inj1e852m8j47gr3qwa33zr7ygptwnz4tyf7ez4f3d";
-const BURN_WALLET_ADDRESS = "inj1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqe2hm49";
 
 // transfer_nft is far heavier than a cw20 transfer, so chunks stay small to
 // keep each tx under the block gas limit.
@@ -179,21 +176,9 @@ const NftAirdropConfirmModal = (props: {
 
     const payFee = useCallback(async () => {
         const injectiveAddress = connectedAddress as string;
-        const totalAmount = props.shroomCost * Math.pow(10, 18);
-        const feeCollectionAmount = (totalAmount * 0.9).toLocaleString("fullwide", { useGrouping: false });
-        const burnAmount = (totalAmount * 0.1).toLocaleString("fullwide", { useGrouping: false });
-
-        const feeMsg = MsgExecuteContract.fromJSON({
-            contractAddress: SHROOM_TOKEN_ADDRESS,
-            sender: injectiveAddress,
-            msg: { transfer: { recipient: FEE_COLLECTION_ADDRESS, amount: feeCollectionAmount } },
-        });
-        const burnMsg = MsgExecuteContract.fromJSON({
-            contractAddress: SHROOM_TOKEN_ADDRESS,
-            sender: injectiveAddress,
-            msg: { transfer: { recipient: BURN_WALLET_ADDRESS, amount: burnAmount } },
-        });
-        return await performTransaction(injectiveAddress, [feeMsg, burnMsg]);
+        // 90% fee / 10% burn, auto-converting bank SHROOM → CW20 when needed.
+        const messages = await buildShroomFeeMessages(injectiveAddress, props.shroomCost, { burn: true });
+        return await performTransaction(injectiveAddress, messages);
     }, [props.shroomCost, connectedAddress]);
 
     const startAirdrop = useCallback(async () => {

--- a/src/views/PresaleTool/AirdropModal.tsx
+++ b/src/views/PresaleTool/AirdropModal.tsx
@@ -1,16 +1,13 @@
 import { useCallback, useState } from "react";
 import { CircleLoader } from "react-spinners";
 import { WALLET_LABELS } from "../../constants/walletLabels";
-import { MsgExecuteContract } from "@injectivelabs/sdk-ts";
 import { useNavigate } from 'react-router-dom';
 import { humanReadableAmount } from "../../utils/helpers";
 import useWalletStore from "../../store/useWalletStore";
 import useNetworkStore from "../../store/useNetworkStore";
 import { performTransaction } from "../../utils/walletStrategy";
 import { sendNativeMultiSend } from "../../utils/multiSend";
-
-const SHROOM_TOKEN_ADDRESS = "inj1300xcg9naqy00fujsr9r8alwk7dh65uqu87xm8"
-const FEE_COLLECTION_ADDRESS = "inj1e852m8j47gr3qwa33zr7ygptwnz4tyf7ez4f3d"
+import { buildShroomFeeMessages } from "../../utils/shroomFee";
 
 interface AirdropRecord {
     address: string;
@@ -53,19 +50,10 @@ const AirdropModal = (props: AirdropModalProps) => {
             setError(null)
         }
 
-        const msg = MsgExecuteContract.fromJSON({
-            contractAddress: SHROOM_TOKEN_ADDRESS,
-            sender: injectiveAddress as string,
-            msg: {
-                transfer: {
-                    recipient: FEE_COLLECTION_ADDRESS,
-                    amount: (shroomFee).toFixed(0) + "0".repeat(18),
-                },
-            },
-        });
-
-        console.log("send shroom fee", msg)
-        return await performTransaction(injectiveAddress as string, [msg])
+        // Auto-converts bank SHROOM → CW20 if the wallet's CW20 balance is short.
+        const messages = await buildShroomFeeMessages(injectiveAddress as string, shroomFee)
+        console.log("send shroom fee", messages)
+        return await performTransaction(injectiveAddress as string, messages)
     }, [shroomFee, connectedAddress])
 
     const sendAirdrops = useCallback(async (denom: string) => {


### PR DESCRIPTION
## What & why

Two related SHROOM improvements:

### 1. `ShroomBalance` prices via Choice
The header balance widget priced holdings through the **DojoSwap** router (SHROOM→INJ × INJ price). It now:
- Quotes via **Choice's optimal router** (`findOptimalRouteV3`, SHROOM→USDC). USDC is dollar-pegged, so the best route's `est_output_amount` is the USD you'd receive selling. Verified against the live endpoint that the query takes/returns human-readable amounts.
- Counts **both CW20 and bank (factory-wrapped) SHROOM** as balance, since both are sellable (the fee flow converts bank→CW20).

### 2. Fee logic auto-converts bank SHROOM → CW20
The SHROOM fee is charged as a CW20 `transfer`, which **fails if the wallet only holds the bank denom**. New shared helper `buildShroomFeeMessages()` ([src/utils/shroomFee.ts](../blob/feat/shroom-fee-auto-convert-and-choice-quote/src/utils/shroomFee.ts)) checks the CW20 balance and, when short, prepends a `redeem_and_transfer` convert message (reusing the existing `createConvertToCw20Message` from the swap flow) to top up from bank SHROOM.

Wired into all **five** fee paths, de-duplicating the fee constants + message construction:
- Airdrop & NFT airdrop modals (90% fee / 10% burn — preserved)
- Presale, Mito market-make, Dojo whitelist (100% fee — preserved)

## Notes
- Fee split math preserved exactly (BigNumber, 90/10).
- If the CW20 balance can't be read, the top-up is skipped (falls back to prior behavior) rather than redeeming bank tokens the user may not hold.
- Independent of the ecosystem-explorer branch — all touched files are identical on `master`.

## Verification
- `tsc --noEmit` ✅ · `eslint` on all changed files ✅ · `vite build` ✅
- Confirmed the Choice quote returns human USDC values against the live endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)