### PR TITLE
feat(airdrop): resumable, idempotent push airdrops

### DIFF
--- a/src/utils/walletStrategy.tsx
+++ b/src/utils/walletStrategy.tsx
@@ -74,6 +74,11 @@ export interface PerformTransactionOptions {
     // gas simulation under-provisions the inner EVM contract creation, so we
     // disable simulation and pass a generous fixed limit instead.
     gas?: number;
+    // Multiplier applied to the simulated gas estimate (default 1.1). Bulk txs
+    // like airdrop multisends occasionally land just over the simulated cost, so
+    // callers can widen the headroom without switching to a fixed limit that
+    // might exceed the block gas cap.
+    gasBufferCoefficient?: number;
 }
 
 export const performTransaction = async (
@@ -93,7 +98,7 @@ export const performTransaction = async (
         simulateTx: !useExplicitGas,
         network: getSelectedNetworkKey(),
         endpoints: getNetworkEndpoints(getSelectedNetworkKey()),
-        gasBufferCoefficient: 1.1,
+        gasBufferCoefficient: opts.gasBufferCoefficient ?? 1.1,
     });
 
     const result = await broadcaster.broadcastV2({

--- a/src/views/Airdrop/AirdropConfirmModal.tsx
+++ b/src/views/Airdrop/AirdropConfirmModal.tsx
@@ -4,7 +4,7 @@ import {
 } from "@injectivelabs/sdk-ts";
 import { buildShroomFeeMessages } from "../../utils/shroomFee";
 import { BigNumberInBase, BigNumberInWei } from "@injectivelabs/utils";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useNavigate } from 'react-router-dom';
 import { CircleLoader } from "react-spinners";
 import { WALLET_LABELS } from "../../constants/walletLabels";
@@ -17,6 +17,21 @@ import { performTransaction } from "../../utils/walletStrategy";
 import { CHUNK_SIZE } from "./distribution";
 import { isValidInjAddress } from "./csv";
 import { humanReadableAmount } from "./format";
+import { downloadCsv } from "../../utils/csv";
+import {
+    clearCheckpoint,
+    loadCheckpoint,
+    markFeePaid,
+    planKey,
+    recordChunkPaid,
+} from "./checkpoint";
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// Widen the simulated-gas headroom for airdrop chunks. A 500-output multisend
+// occasionally lands just over the 1.1x default and fails; 1.3x costs nothing
+// extra (gas is charged on use, not on the limit) and removes that failure mode.
+const AIRDROP_GAS_BUFFER = 1.3;
 
 const INSERT_AIRDROP_MUTATION = gql`
 mutation insertAirdropLog (
@@ -87,13 +102,16 @@ const AirdropConfirmModal = (props: {
     const [progress, setProgress] = useState("")
     const [txLoading, setTxLoading] = useState(false)
 
-    const [error, setError] = useState(null)
+    const [error, setError] = useState<string | null>(null)
 
     const [feePayed, setFeePayed] = useState(false)
 
     const [estimatedTx, setEstimatedTx] = useState<number | null>(null)
     const [completedTx, setCompletedTx] = useState(0)
 
+    // Resume/idempotency state, seeded from the persisted checkpoint (if any).
+    const [paidCount, setPaidCount] = useState(0)
+    const [failedChunks, setFailedChunks] = useState<number[]>([])
 
     const [insertAirdropLog] = useMutation(INSERT_AIRDROP_MUTATION)
     const [insertWallets] = useMutation(INSERT_WALLETS_MUTATION)
@@ -123,7 +141,45 @@ const AirdropConfirmModal = (props: {
     );
     const txCount = Math.ceil(payable.length / CHUNK_SIZE);
 
-    const sendAirdrops = useCallback(async (denom: any, decimals: number | undefined, airdropDetails: any[]) => {
+    // The exact `{address, amount}` rows that will be sent — the single source of
+    // truth for both the send loop and the checkpoint key, so the key always
+    // matches what actually goes out.
+    const payableRecords = useMemo<{ address: string; amount: string }[]>(
+        () =>
+            (props.airdropDetails || [])
+                .filter(isPayable)
+                .filter((r: any) => isValidInjAddress(r.address))
+                .map((r: any) => ({
+                    address: r.address as string,
+                    amount: Number(r.amountToAirdrop).toFixed(props.tokenDecimals),
+                })),
+        [props.airdropDetails, isPayable, props.tokenDecimals],
+    );
+
+    // Stable per-plan checkpoint key (sender + token + sorted address/amount set).
+    const checkpointKey = useMemo(
+        () =>
+            connectedAddress && payableRecords.length > 0
+                ? planKey(connectedAddress, props.tokenAddress, payableRecords)
+                : null,
+        [connectedAddress, props.tokenAddress, payableRecords],
+    );
+
+    // Rehydrate resume state from any persisted checkpoint for this exact plan:
+    // how many recipients were already paid, and whether the fee was already
+    // charged (so a resumed run never double-charges).
+    useEffect(() => {
+        if (!checkpointKey) {
+            setPaidCount(0);
+            return;
+        }
+        const cp = loadCheckpoint(checkpointKey);
+        setPaidCount(cp?.paid.length ?? 0);
+        setCompletedTx(cp?.txHashes.length ?? 0);
+        if (cp?.feePaid) setFeePayed(true);
+    }, [checkpointKey]);
+
+    const sendAirdrops = useCallback(async (denom: any, decimals: number | undefined) => {
 
         const injectiveAddress = connectedAddress as string
 
@@ -131,19 +187,14 @@ const AirdropConfirmModal = (props: {
             throw new Error("You are connected to the wrong address")
         }
 
-        const records = airdropDetails
-            .filter(isPayable)
-            .filter((record: { address: string }) => isValidInjAddress(record.address))
-            .map((record: { address: any; amountToAirdrop: any; }) => {
-                return {
-                    address: record.address,
-                    amount: Number(record.amountToAirdrop).toFixed(props.tokenDecimals)
-                }
-            });
+        const records = payableRecords;
 
         if (records.length === 0) {
             throw new Error("No valid recipients to airdrop to")
         }
+
+        const key = checkpointKey;
+        const base = { sender: injectiveAddress, token: props.tokenAddress, total: records.length };
 
         const isNative = (
             denom.includes("factory") ||
@@ -153,30 +204,40 @@ const AirdropConfirmModal = (props: {
         )
 
         const chunkSize = CHUNK_SIZE;
-        const gasPerRecord = isNative ? 40000 : 80000;
-        const chunks = [];
+        const chunks: { address: string; amount: string }[][] = [];
 
         for (let i = 0; i < records.length; i += chunkSize) {
             chunks.push(records.slice(i, i + chunkSize));
         }
 
-        const successfullyProcessed = new Set();
+        // Resume: seed the already-paid set and landed hashes from the persisted
+        // checkpoint so recipients paid on a previous attempt are never paid
+        // again — this is what makes a half-finished run continuable.
+        const prior = key ? loadCheckpoint(key) : null;
+        const successfullyProcessed = new Set<string>(prior?.paid ?? []);
+        const transactions: string[] = [...(prior?.txHashes ?? [])];
 
-        const transactions = []
         setEstimatedTx(chunks.length)
+        setCompletedTx(transactions.length)
+        setPaidCount(successfullyProcessed.size)
 
-        for (const chunk of chunks) {
+        // Chunks that couldn't be sent after their retries. We record them and
+        // keep going instead of aborting the whole run, so one bad chunk no
+        // longer strands the other 35.
+        const failed: number[] = [];
+
+        for (let ci = 0; ci < chunks.length; ci++) {
+            const filteredChunk = chunks[ci].filter(record => !successfullyProcessed.has(record.address));
+
+            if (filteredChunk.length === 0) {
+                continue; // every recipient in this chunk was already paid
+            }
+
             let retries = 3;
             let success = false;
 
             while (retries > 0 && !success) {
                 try {
-                    const filteredChunk = chunk.filter(record => !successfullyProcessed.has(record.address));
-
-                    if (filteredChunk.length === 0) {
-                        break;
-                    }
-
                     let msg;
                     if (!isNative) {
                         msg = filteredChunk.map((record) => {
@@ -226,43 +287,38 @@ const AirdropConfirmModal = (props: {
                         });
                     }
 
-                    let calculatedGas = filteredChunk.length * gasPerRecord;
-                    if (calculatedGas < 5000000) {
-                        calculatedGas = 5000000;
-                    }
+                    const response = await performTransaction(injectiveAddress, msg as any, {
+                        gasBufferCoefficient: AIRDROP_GAS_BUFFER,
+                    });
 
-                    const gas = {
-                        amount: [
-                            {
-                                denom: "inj",
-                                amount: calculatedGas.toString()
-                            }
-                        ],
-                        gas: calculatedGas.toString()
-                    };
-
-                    console.log("gas", gas)
-                    console.log("msg", msg)
-
-                    const response = await performTransaction(injectiveAddress, msg as any);
+                    // Persist progress BEFORE anything else can throw, so a crash
+                    // right after broadcast can't lose a landed tx.
                     filteredChunk.forEach(record => successfullyProcessed.add(record.address));
-
-                    success = true;
                     transactions.push(response!.txHash)
+                    if (key) {
+                        recordChunkPaid(key, base, filteredChunk.map(r => r.address), response!.txHash);
+                    }
                     setCompletedTx(transactions.length)
+                    setPaidCount(successfullyProcessed.size)
+                    success = true;
                 } catch (error) {
-                    console.error("Transaction failed, retrying...", error);
+                    console.error(`Chunk ${ci + 1}/${chunks.length} failed, retrying...`, error);
                     retries -= 1;
+                    if (retries > 0) {
+                        await sleep(1000 * (3 - retries)); // 1s, then 2s backoff
+                    }
                 }
             }
 
             if (!success) {
-                console.error("Failed to send airdrop after multiple retries");
-                throw new Error("Failed to send airdrop after multiple retries");
+                console.error(`Chunk ${ci + 1}/${chunks.length} failed after retries — continuing`);
+                failed.push(ci);
             }
         }
-        return transactions
-    }, [connectedAddress, props.tokenDecimals, isPayable]);
+
+        setFailedChunks(failed)
+        return { txHashes: transactions, failed }
+    }, [connectedAddress, payableRecords, checkpointKey, props.tokenAddress]);
 
     const payFee = useCallback(async () => {
         const injectiveAddress = connectedAddress as string;
@@ -270,12 +326,23 @@ const AirdropConfirmModal = (props: {
         // CW20 balance can't cover the fee.
         const messages = await buildShroomFeeMessages(injectiveAddress, props.shroomCost, { burn: true });
         console.log("send shroom fee", messages);
-        return await performTransaction(injectiveAddress, messages);
-    }, [props.shroomCost, connectedAddress]);
+        const result = await performTransaction(injectiveAddress, messages);
+        // Persist that the fee was charged so a resumed/retried run (even after a
+        // page reload) never bills the SHROOM fee a second time.
+        if (result && checkpointKey) {
+            markFeePaid(checkpointKey, {
+                sender: injectiveAddress,
+                token: props.tokenAddress,
+                total: payableRecords.length,
+            });
+        }
+        return result;
+    }, [props.shroomCost, connectedAddress, checkpointKey, props.tokenAddress, payableRecords.length]);
 
     const startAirdrop = useCallback(async () => {
         setError(null)
         if (props.airdropDetails !== null && props.airdropDetails.length > 0) {
+            setTxLoading(true)
 
             // pay fee
             if (currentNetwork == "mainnet" && props.shroomCost !== 0 && !feePayed) {
@@ -287,17 +354,38 @@ const AirdropConfirmModal = (props: {
 
             console.log("airdrop")
             setProgress("Send airdrops")
-            const txHashes = await sendAirdrops(props.tokenAddress, props.tokenDecimals, props.airdropDetails)
-            setProgress("Done...")
-            console.log(txHashes)
+            const { txHashes, failed } = await sendAirdrops(props.tokenAddress, props.tokenDecimals)
+            const partial = failed.length > 0
+            setProgress(partial ? "" : "Done...")
+            setTxLoading(false)
+            console.log(txHashes, "failed chunks:", failed)
+
+            // Who actually got paid (from the checkpoint's confirmed set) — so
+            // logs and receipts reflect reality even on a partial run.
+            const finalCp = checkpointKey ? loadCheckpoint(checkpointKey) : null
+            const paidSet = new Set<string>(finalCp?.paid ?? [])
+            const paidRecipients = partial
+                ? payable.filter((w: any) => paidSet.has(w.address))
+                : payable
+            const paidOut = partial
+                ? paidRecipients.reduce(
+                    (s: number, r: any) => s + Number(Number(r.amountToAirdrop).toFixed(props.tokenDecimals)),
+                    0,
+                )
+                : totalOut
+            const partialNote = partial
+                ? ` [partial: ${paidRecipients.length}/${payable.length} recipients paid, ${failed.length} chunk(s) failed]`
+                : ""
 
             if (currentNetwork == "mainnet") await sendTelegramMessage(
-                `wallet ${connectedAddress} performed an airdrop on trippyinj!\ntoken dropped: ${props.tokenAddress}\n` +
-                `num participants: ${payable.length}\n` +
+                `wallet ${connectedAddress} performed an airdrop on trippyinj!${partialNote}\ntoken dropped: ${props.tokenAddress}\n` +
+                `num participants: ${paidRecipients.length}\n` +
                 `${props.criteria}\n${props.description}`
             )
 
-            if (currentNetwork == "mainnet") {
+            // Persist a log whenever at least one tx landed, so the hashes are
+            // never orphaned — including partial runs.
+            if (currentNetwork == "mainnet" && txHashes.length > 0) {
                 try {
                     await insertTokenDropped({
                         variables: {
@@ -307,7 +395,7 @@ const AirdropConfirmModal = (props: {
 
                     await insertWallets({
                         variables: {
-                            objects: payable.map((wallet: any) => ({
+                            objects: paidRecipients.map((wallet: any) => ({
                                 address: wallet.address,
                                 burn_address: false
                             }))
@@ -319,15 +407,15 @@ const AirdropConfirmModal = (props: {
                             "time": dayjs(),
                             "token_dropped_id": props.tokenAddress,
                             "wallet_id": connectedAddress,
-                            "amount_dropped": totalOut,
-                            "total_participants": payable.length,
-                            "participants": payable.map((wallet: any) => {
+                            "amount_dropped": paidOut,
+                            "total_participants": paidRecipients.length,
+                            "participants": paidRecipients.map((wallet: any) => {
                                 return {
                                     "wallet_id": wallet.address
                                 }
                             }),
                             "criteria": props.criteria,
-                            "description": props.description,
+                            "description": (props.description ?? "") + partialNote,
                             "tx_hashes": txHashes.join(","),
                             "fee": props.shroomCost.toString()
                         }
@@ -342,9 +430,44 @@ const AirdropConfirmModal = (props: {
                 }
             }
 
+            if (partial) {
+                // Keep the checkpoint so the user can retry only the failed
+                // chunks; surface a clear, actionable message.
+                setError(
+                    `Sent to ${paidRecipients.length}/${payable.length} recipients. ` +
+                    `${failed.length} transaction(s) failed. Your progress is saved — ` +
+                    `click "Retry failed" to send only the remaining recipients.`,
+                )
+                return
+            }
+
+            if (checkpointKey) clearCheckpoint(checkpointKey)
             void navigate('/airdrop-history');
         }
-    }, [props.airdropDetails, props.shroomCost, props.tokenAddress, props.tokenDecimals, feePayed, currentNetwork, sendAirdrops, connectedAddress, navigate, payFee, insertAirdropLog, props.criteria, props.description, insertWallets, insertTokenDropped, payable, totalOut])
+    }, [props.airdropDetails, props.shroomCost, props.tokenAddress, props.tokenDecimals, feePayed, currentNetwork, sendAirdrops, connectedAddress, navigate, payFee, insertAirdropLog, props.criteria, props.description, insertWallets, insertTokenDropped, payable, totalOut, checkpointKey])
+
+    // Reconciliation receipt: every intended recipient with its amount and
+    // whether it's been paid yet — handy after a partial run.
+    const downloadReceipt = useCallback(() => {
+        const cp = checkpointKey ? loadCheckpoint(checkpointKey) : null;
+        const paidSet = new Set<string>(cp?.paid ?? []);
+        const header = "address,amount,status";
+        const rows = payableRecords.map(
+            (r) => `${r.address},${r.amount},${paidSet.has(r.address) ? "paid" : "pending"}`,
+        );
+        downloadCsv(
+            `airdrop-receipt-${props.tokenSymbol ?? "token"}.csv`,
+            [header, ...rows].join("\n"),
+        );
+    }, [checkpointKey, payableRecords, props.tokenSymbol]);
+
+    const hasProgress = paidCount > 0;
+    const remaining = Math.max(0, payable.length - paidCount);
+    const actionLabel = failedChunks.length > 0
+        ? `Retry failed (${remaining} left)`
+        : hasProgress
+            ? `Resume airdrop (${remaining} left)`
+            : "Do Airdrop";
 
     return (
         <>
@@ -444,17 +567,34 @@ const AirdropConfirmModal = (props: {
                             {txLoading && <CircleLoader color="#36d7b7" className="mt-2 m-auto" />}
                             {error && <div className="text-rose-600 mt-5">{error}</div>}
                         </div>
-                        {estimatedTx !== null &&
-                            <div className="mx-5 mb-2">
-                                <div>
-                                    Total number of tx for airdrop: {estimatedTx}
+                        {(estimatedTx !== null || hasProgress) &&
+                            <div className="mx-5 mb-2 rounded-md bg-slate-900 p-3">
+                                <div className="flex flex-wrap gap-x-6 gap-y-1">
+                                    <div>Recipients paid: <b>{paidCount}</b> / {payable.length}</div>
+                                    {estimatedTx !== null &&
+                                        <div>Completed tx: <b>{completedTx}</b> / {estimatedTx}</div>
+                                    }
+                                    {remaining > 0 && <div>Remaining: <b>{remaining}</b></div>}
+                                    {failedChunks.length > 0 &&
+                                        <div className="text-rose-400">Failed tx: <b>{failedChunks.length}</b></div>
+                                    }
                                 </div>
-                                <div>
-                                    Completed tx: {completedTx}
-                                </div>
+                                {hasProgress &&
+                                    <div className="mt-2 text-xs text-slate-400">
+                                        Progress is saved. If a run stops early, click&nbsp;
+                                        <b>{actionLabel}</b>&nbsp;— already-paid recipients are skipped.
+                                        <button
+                                            type="button"
+                                            onClick={downloadReceipt}
+                                            className="ml-2 underline text-indigo-300"
+                                        >
+                                            Download receipt
+                                        </button>
+                                    </div>
+                                }
                             </div>
                         }
-                        <div className="mx-5">If the airdrop TX fails, try increasing the gas fee in your wallet. Each tx will retry up to 3 times.</div>
+                        <div className="mx-5 text-xs text-slate-400">Each transaction retries up to 3 times with backoff. A failed transaction no longer aborts the whole airdrop — your progress is saved and you can retry the rest.</div>
                         {currentNetwork == "mainnet" && (props.airdropDetails.length > 0) && <div className="m-5">
                             Fee for airdrop: {props.shroomCost} shroom (cw20)<br />
                             <a href="https://coinhall.org/injective/inj1m35kyjuegq7ruwgx787xm53e5wfwu6n5uadurl" className="underline text-sm">buy here</a>
@@ -471,8 +611,9 @@ const AirdropConfirmModal = (props: {
                                 Back
                             </button>
                             <button
-                                className="bg-gray-600 text-white active:bg-emerald-600 font-bold uppercase text-sm px-6 py-3 rounded-sm shadow-sm hover:shadow-lg outline-hidden focus:outline-hidden mr-1 mb-1 ease-linear transition-all duration-150"
+                                className="bg-gray-600 text-white active:bg-emerald-600 font-bold uppercase text-sm px-6 py-3 rounded-sm shadow-sm hover:shadow-lg outline-hidden focus:outline-hidden mr-1 mb-1 ease-linear transition-all duration-150 disabled:opacity-50 disabled:cursor-not-allowed"
                                 type="button"
+                                disabled={txLoading}
                                 onClick={() => { void startAirdrop().then(() => console.log("done")).catch(e => {
                                     console.log(e)
                                     setError(e.message)
@@ -480,7 +621,7 @@ const AirdropConfirmModal = (props: {
                                     setTxLoading(false)
                                 }); }}
                             >
-                                Do Airdrop
+                                {actionLabel}
                             </button>
                         </div>
                     </div>

--- a/src/views/Airdrop/checkpoint.ts
+++ b/src/views/Airdrop/checkpoint.ts
@@ -1,0 +1,185 @@
+// Durable, resumable checkpoint for the push-airdrop flow.
+//
+// A push airdrop is N sequential signed transactions (one per 500-recipient
+// chunk). Before this, all progress lived in a component-local Set: if the run
+// died on chunk 18/36 the 17 landed txs were forgotten, and clicking "Do
+// Airdrop" again re-sent to *everyone* from chunk 0 — double-paying the first
+// 8,500 recipients.
+//
+// This module persists the set of addresses that have actually been paid (plus
+// the landed tx hashes and whether the SHROOM fee was paid) to localStorage,
+// keyed by a hash of the plan. On the next attempt the sender skips anyone
+// already paid, so a run can be resumed — even after a page reload — and can
+// never double-pay.
+//
+// Why the *paid-address set* and not "completed chunk indices": chunk indices
+// are only stable if the recipient list keeps byte-identical ordering. A holder
+// query can return the same wallets in a different order across reloads, which
+// would shift the chunk boundaries and skip the wrong people. The paid-set is
+// order-independent and therefore correct regardless of how the plan is rebuilt.
+
+export interface AirdropCheckpoint {
+    v: number;
+    sender: string;
+    token: string;
+    /** Addresses confirmed paid (a landed tx included them). */
+    paid: string[];
+    /** Landed tx hashes, in the order they confirmed. */
+    txHashes: string[];
+    /** SHROOM fee already paid for this plan (don't charge again on resume). */
+    feePaid: boolean;
+    /** Total payable recipients in the plan — for progress display only. */
+    total: number;
+    updatedAt: number;
+}
+
+const PREFIX = "trippy.airdrop.ckpt.";
+const INDEX_KEY = "trippy.airdrop.ckpt.index";
+// Keep only the most recent few checkpoints so a big paid-set (17k addresses ≈
+// ~800KB) can't accumulate and blow the ~5MB iOS localStorage cap.
+const MAX_CHECKPOINTS = 3;
+
+const CURRENT_VERSION = 1;
+
+// cyrb53 — a fast, well-distributed 53-bit string hash. Not cryptographic; we
+// only need a stable, collision-resistant key for the plan.
+function cyrb53(str: string, seed = 0): string {
+    let h1 = 0xdeadbeef ^ seed;
+    let h2 = 0x41c6ce57 ^ seed;
+    for (let i = 0; i < str.length; i++) {
+        const ch = str.charCodeAt(i);
+        h1 = Math.imul(h1 ^ ch, 2654435761);
+        h2 = Math.imul(h2 ^ ch, 1597334677);
+    }
+    h1 = Math.imul(h1 ^ (h1 >>> 16), 2246822507);
+    h1 ^= Math.imul(h2 ^ (h2 >>> 13), 3266489909);
+    h2 = Math.imul(h2 ^ (h2 >>> 16), 2246822507);
+    h2 ^= Math.imul(h1 ^ (h1 >>> 13), 3266489909);
+    return (4294967296 * (2097151 & h2) + (h1 >>> 0)).toString(16);
+}
+
+/**
+ * Deterministic key for a plan. Built from the sender, the token, and the
+ * *sorted* set of `address:amount` pairs, so the same drop always maps to the
+ * same checkpoint no matter what order the recipient list is built in — and any
+ * change to who gets what (or how much) starts a fresh, independent checkpoint.
+ */
+export function planKey(
+    sender: string,
+    token: string,
+    records: { address: string; amount: string }[],
+): string {
+    const body = records
+        .map((r) => `${r.address}:${r.amount}`)
+        .sort()
+        .join("|");
+    return cyrb53(`${sender}|${token}|${records.length}|${body}`);
+}
+
+function storageKey(key: string): string {
+    return PREFIX + key;
+}
+
+function readIndex(): string[] {
+    try {
+        const raw = localStorage.getItem(INDEX_KEY);
+        return raw ? (JSON.parse(raw) as string[]) : [];
+    } catch {
+        return [];
+    }
+}
+
+// Track this key as most-recently-used and evict the oldest checkpoints beyond
+// MAX_CHECKPOINTS so storage stays bounded.
+function touchIndex(key: string): void {
+    try {
+        const idx = readIndex().filter((k) => k !== key);
+        idx.push(key);
+        while (idx.length > MAX_CHECKPOINTS) {
+            const evict = idx.shift();
+            if (evict) localStorage.removeItem(storageKey(evict));
+        }
+        localStorage.setItem(INDEX_KEY, JSON.stringify(idx));
+    } catch {
+        // best effort — pruning is not correctness-critical
+    }
+}
+
+export function loadCheckpoint(key: string): AirdropCheckpoint | null {
+    try {
+        const raw = localStorage.getItem(storageKey(key));
+        if (!raw) return null;
+        const cp = JSON.parse(raw) as AirdropCheckpoint;
+        if (!cp || cp.v !== CURRENT_VERSION) return null;
+        return cp;
+    } catch {
+        return null;
+    }
+}
+
+// Persist a checkpoint. Never throws: on a quota/security error (iOS private
+// mode, over-quota) we simply keep going in memory — the caller's live Set
+// still prevents double-pays within the session, we just lose cross-reload
+// resume for this plan.
+function persist(key: string, cp: AirdropCheckpoint): void {
+    try {
+        localStorage.setItem(storageKey(key), JSON.stringify(cp));
+        touchIndex(key);
+    } catch (e) {
+        console.warn("[airdrop-checkpoint] could not persist checkpoint", e);
+    }
+}
+
+/** Merge a freshly-confirmed chunk (its addresses + tx hash) into the checkpoint. */
+export function recordChunkPaid(
+    key: string,
+    base: { sender: string; token: string; total: number },
+    addresses: string[],
+    txHash: string,
+): AirdropCheckpoint {
+    const existing = loadCheckpoint(key);
+    const paid = new Set(existing?.paid ?? []);
+    addresses.forEach((a) => paid.add(a));
+    const txHashes = existing?.txHashes ?? [];
+    if (txHash && !txHashes.includes(txHash)) txHashes.push(txHash);
+    const cp: AirdropCheckpoint = {
+        v: CURRENT_VERSION,
+        sender: base.sender,
+        token: base.token,
+        paid: Array.from(paid),
+        txHashes,
+        feePaid: existing?.feePaid ?? false,
+        total: base.total,
+        updatedAt: Date.now(),
+    };
+    persist(key, cp);
+    return cp;
+}
+
+export function markFeePaid(
+    key: string,
+    base: { sender: string; token: string; total: number },
+): void {
+    const existing = loadCheckpoint(key);
+    const cp: AirdropCheckpoint = {
+        v: CURRENT_VERSION,
+        sender: base.sender,
+        token: base.token,
+        paid: existing?.paid ?? [],
+        txHashes: existing?.txHashes ?? [],
+        feePaid: true,
+        total: base.total,
+        updatedAt: Date.now(),
+    };
+    persist(key, cp);
+}
+
+export function clearCheckpoint(key: string): void {
+    try {
+        localStorage.removeItem(storageKey(key));
+        const idx = readIndex().filter((k) => k !== key);
+        localStorage.setItem(INDEX_KEY, JSON.stringify(idx));
+    } catch {
+        // ignore
+    }
+}


### PR DESCRIPTION
## Problem

A push airdrop is N sequential signed txs (500 recipients each). Today all progress lives in a component-local `Set`, so:

- A run that dies on chunk 18/36 (exactly the screenshot that kicked this off) **forgets the 17 landed txs** — no backend log, hashes lost.
- Clicking **Do Airdrop** again re-runs from chunk 0 with a fresh set → **re-pays the first ~8,500 recipients** (silent double-send).
- One chunk that fails its 3 retries **throws and aborts the whole airdrop**, stranding the other 35.
- The computed gas object was **dead code** — never passed to the broadcaster; the modal's "increase gas in your wallet" advice was misleading.

## What this does

Makes a push airdrop **resumable and idempotent** — a half-finished run continues where it left off and can never double-pay.

- **`checkpoint.ts`** (new): durable `localStorage` checkpoint keyed by a hash of the plan (sender + token + *sorted* address/amount set). Persists the **paid-address set** (order-independent → correct across reloads and list reordering), landed tx hashes, and whether the SHROOM fee was paid. Bounded to the 3 most recent plans; writes never throw (iOS quota / private mode degrade to in-memory).
- **`sendAirdrops`**: seeds the paid set from the checkpoint and **skips anyone already paid** (kills the double-send), persists after **every confirmed chunk**, and **no longer aborts on a failed chunk** — it records it and keeps going. Adds 1s/2s retry backoff.
- **Fee never re-charged** on resume/retry (checkpoint `feePaid` + component state), even after a page reload.
- **Partial runs are still logged** to the backend so landed hashes aren't orphaned; log + telegram note the partial status.
- **Gas**: threads a configurable `gasBufferCoefficient` through `performTransaction` and widens airdrop chunks to **1.3×**. Simulation stays on (no fixed limit that could exceed the block gas cap).
- **UI**: action button reads **"Resume airdrop (N left)"** / **"Retry failed (N left)"** when a checkpoint exists; live *recipients paid / remaining / failed* counters; **Download receipt** CSV (`address,amount,paid|pending`).

## Scope / follow-ups

- Frontend-only, no backend migration (matches the auto-deploy-on-push flow). A first-class `status` column on `airdrop_tracker_airdroplog` (pending/partial/complete) is a sensible follow-up so History can show partial drops explicitly.
- This is **Option A** from the review. Option B (claimable / merkle airdrops) is still open for large drops.

## Test plan

- `tsc --noEmit` ✓ · `eslint` (changed files) ✓ · `vite build` ✓
- Manual QA before merge (auto-deploys live): testnet drop, kill the tab mid-run, reopen → button shows **Resume (N left)**, only unpaid recipients go out; force a chunk failure → run finishes the rest, **Retry failed** sends only the remainder; confirm the SHROOM fee is charged once across resumes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)