### PR TITLE
fix(wallet-modal): center connect-wallet modal + SHROOM-launchpad styling

### DIFF
--- a/src/components/Modals/WalletSelectModal.tsx
+++ b/src/components/Modals/WalletSelectModal.tsx
@@ -1,3 +1,5 @@
+import { useEffect } from "react";
+import { createPortal } from "react-dom";
 import { Link } from "react-router-dom";
 import leapLogo from '../../assets/leap-dark.svg';
 import keplrLogo from '../../assets/keplr.png'
@@ -7,61 +9,93 @@ import phantom from '../../assets/phantom.svg'
 import useWalletStore from "../../store/useWalletStore";
 import { useWalletConnect } from "../WalletConnect";
 
+// Styled after the SHROOM launchpad wallet picker: portal + blur backdrop, a
+// scale-in card centered with top/left 50% + translate(-50%,-50%) (the old
+// modal mixed flex-centering with a stray -translate-x-1/2, which shoved it
+// off-screen left on mobile), responsive width, and the trippyYellow accent.
 export default function WalletSelectModal() {
   const { showWallets, setShowWallets } = useWalletStore()
   const { handleKeplrClick, handleLeapClick, handleMetamaskClick, handlePhantomClick } = useWalletConnect()
 
-  const handleToggleWallets = () => {
-    setShowWallets(!showWallets)
-  }
+  // ESC to close + lock body scroll while the modal is open.
+  useEffect(() => {
+    if (!showWallets) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setShowWallets(false);
+    };
+    window.addEventListener("keydown", onKey);
+    const prevOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      window.removeEventListener("keydown", onKey);
+      document.body.style.overflow = prevOverflow;
+    };
+  }, [showWallets, setShowWallets]);
 
   if (!showWallets) return null
-  return (
-    <div className="fixed inset-0 flex items-center justify-center z-50">
+
+  const wallets = [
+    { key: "keplr", label: "Keplr Wallet", sub: "Cosmos", logo: keplrLogo, onClick: () => { void handleKeplrClick(); } },
+    { key: "leap", label: "Leap Wallet", sub: "Cosmos", logo: leapLogo, onClick: () => { void handleLeapClick(); } },
+    { key: "metamask", label: "Metamask", sub: "EVM", logo: metamask, onClick: () => { void handleMetamaskClick(); } },
+    { key: "phantom", label: "Phantom", sub: "EVM", logo: phantom, onClick: () => { void handlePhantomClick(); } },
+  ]
+
+  return createPortal(
+    <div role="dialog" aria-modal="true" aria-labelledby="wallet-modal-title">
       <div
-        className="fixed inset-0 bg-black opacity-50"
-        onClick={handleToggleWallets}
+        onClick={() => setShowWallets(false)}
+        className="fixed inset-0 z-100 bg-[rgba(8,6,12,0.65)] backdrop-blur-md modal-backdrop-fade"
       />
-      <div className="bg-[#0F0F0F] rounded-lg shadow-lg  p-6  -translate-x-1/2 z-20 slide-in text-white w-[500px]">
-        <div className='flex  justify-between mb-2'>
-          <div>
-            <h3 className=' font-montserrat text-xl font-semibold mb-2'>Connect Wallet</h3>
-          </div>
 
-          <button onClick={
-            handleToggleWallets
-          } className="bg-[#191919] w-8 h-8 flex items-center justify-center rounded-full shadow-md hover:shadow-[0_0_8px_3px_#f9d73f] 
-               transition duration-300  ">
-            <i className="fa-solid fa-x"></i>
-          </button>
+      <div
+        onClick={(e) => e.stopPropagation()}
+        style={{ transform: "translate(-50%, -50%)" }}
+        className="fixed left-1/2 top-1/2 z-101 modal-pop w-[min(460px,calc(100vw-24px))] max-h-[calc(100vh-24px)] overflow-y-auto rounded-2xl border border-white/10 bg-[#0F0F0F] p-5 sm:p-6 text-white shadow-[0_24px_64px_rgba(0,0,0,0.55)]"
+      >
+        <button
+          type="button"
+          onClick={() => setShowWallets(false)}
+          aria-label="Close"
+          className="absolute right-3 top-3 grid h-8 w-8 place-items-center rounded-full border border-white/10 bg-[#191919] text-gray-400 transition duration-200 hover:border-trippyYellow hover:bg-trippyYellow hover:text-black"
+        >
+          ✕
+        </button>
+
+        <h2 id="wallet-modal-title" className="font-magic text-xl font-bold tracking-tight">
+          Connect Wallet
+        </h2>
+        <p className="mt-1.5 mb-5 text-xs text-gray-400">
+          Choose a wallet to connect to Injective.
+        </p>
+
+        <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+          {wallets.map((w) => (
+            <button
+              key={w.key}
+              type="button"
+              onClick={w.onClick}
+              className="flex items-center gap-3 rounded-[10px] border border-white/10 bg-white/2 p-3 text-left transition duration-150 hover:border-trippyYellow hover:bg-trippyYellow/10"
+            >
+              <img src={w.logo} alt="" className="h-8 w-8 shrink-0 rounded-md object-contain" />
+              <div className="min-w-0">
+                <div className="text-sm font-semibold text-white">{w.label}</div>
+                <div className="text-[10px] uppercase tracking-[0.08em] text-gray-500">{w.sub}</div>
+              </div>
+            </button>
+          ))}
         </div>
 
-
-        <div className='flex flex-col text-white gap-2 mb-10'>
-          <div onClick={() => { void handleKeplrClick(); }} className='flex border border-gray-600 rounded-md w-full p-4 gap-3 items-center cursor-pointer hover:border-trippyYellow'>
-            <img src={keplrLogo} className='h-8 ' alt="" /><span>Keplr Wallet</span>
-          </div>
-          <div onClick={() => { void handleLeapClick(); }} className='flex border border-gray-600 rounded-md w-full p-4 gap-3 items-center cursor-pointer hover:border-trippyYellow'>
-            <img src={leapLogo} className='h-8 rounded-sm' alt="" /><span>Leap Wallet</span>
-          </div>
-          <div onClick={() => { void handleMetamaskClick(); }} className='flex border border-gray-600 rounded-md w-full p-4 gap-3 items-center cursor-pointer hover:border-trippyYellow'>
-            <img src={metamask} className='h-8' alt="" /><span>Metamask Wallet</span>
-          </div>
-          <div onClick={() => { void handlePhantomClick(); }} className='flex border border-gray-600 rounded-md w-full p-4 gap-3 items-center cursor-pointer hover:border-trippyYellow'>
-            <img src={phantom} className='h-8 rounded-sm' alt="" /><span>Phantom Wallet</span>
-          </div>
-        </div>
-
-
-        <div className="w-100 text-center">
+        <div className="mt-4 border-t border-white/10 pt-3 text-center text-[11px] text-gray-500">
           <Link
-            to={"https://medium.com/@ChoiceExchange/set-up-an-injective-wallet-3ef43f359f76"}
-            // onClick={handleToggleWallets}
-            className='text-white font-montserrat underline hover:opacity-80'>
+            to="https://medium.com/@ChoiceExchange/set-up-an-injective-wallet-3ef43f359f76"
+            className="text-trippyYellow underline underline-offset-2 hover:opacity-80"
+          >
             How to create an Injective wallet?
           </Link>
         </div>
       </div>
-    </div>
+    </div>,
+    document.body,
   )
 }

--- a/src/index.css
+++ b/src/index.css
@@ -156,3 +156,21 @@ body {
 .slide-in {
   animation: slideInFromBottom 100ms ease-in forwards;
 }
+
+/* Modal enter animations (SHROOM-launchpad style): fade the backdrop and
+   scale-in the centered card. The card keyframes carry the translate(-50%,-50%)
+   so the centering survives the animation and its `forwards` resting state. */
+@keyframes modalBackdropFade {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+@keyframes modalPop {
+  from { opacity: 0; transform: translate(-50%, -50%) scale(0.96); }
+  to { opacity: 1; transform: translate(-50%, -50%) scale(1); }
+}
+.modal-backdrop-fade {
+  animation: modalBackdropFade 140ms ease-out;
+}
+.modal-pop {
+  animation: modalPop 180ms cubic-bezier(0.16, 1, 0.3, 1) forwards;
+}


### PR DESCRIPTION
## Problem

The connect-wallet modal was **shoved off-screen left and cut off on mobile** (and off-centre on desktop): the card mixed flex-centering with a leftover `-translate-x-1/2`, so it moved ~250px left of centre. Its fixed `w-[500px]` also overflowed narrow phones.

| before | after (desktop) | after (mobile) |
|---|---|---|
| off-screen left, cut off | dead-centre | centred, fits, single-column |

## Change

Restyled after the SHROOM launchpad wallet modal, using trippytools' own tokens (`trippyYellow`, `font-magic`, `#0F0F0F`):

- **Portal** to `<body>` with a blurred backdrop.
- **Centered** via `top/left: 50%` + `translate(-50%,-50%)` — carried through the scale-in keyframe so centering survives the animation and its `forwards` resting state.
- **Responsive**: `width: min(460px, 100vw - 24px)`, `max-height: calc(100vh - 24px)` with scroll.
- Rounded card, circular close button (hover → trippyYellow), 2-col wallet grid (1-col on mobile) with Cosmos/EVM sublines.
- **ESC-to-close** + body-scroll-lock while open.
- Adds `modalPop` / `modalBackdropFade` keyframes to `index.css`.

Behaviour is unchanged — same `useWalletConnect` handlers (Keplr / Leap / Metamask / Phantom).

## Verified

`tsc` ✓ · `eslint` ✓ · `vite build` ✓. Rendered the compiled CSS + exact markup in headless Chrome at **1280px** and **390px** — modal is centred and fully on-screen at both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)