### PR TITLE
fix(charts): silence recharts ResponsiveContainer -1/-1 warning

### DIFF
--- a/src/components/App/markets/CandleChart.tsx
+++ b/src/components/App/markets/CandleChart.tsx
@@ -98,7 +98,12 @@ interface CandleChartProps {
 }
 
 const CandleChart = ({ candles, denom, quoteSymbol }: CandleChartProps) => (
-    <ResponsiveContainer width="100%" height="100%">
+    // initialDimension seeds a positive first-render size so ResponsiveContainer
+    // doesn't log the "width(-1) and height(-1)" warning on mount (its default
+    // is -1/-1, and a 100%/100% container computes -1 until the ResizeObserver
+    // measures the real size on the next frame). Values are placeholders; the
+    // observer immediately corrects them to the parent's actual size.
+    <ResponsiveContainer width="100%" height="100%" initialDimension={{ width: 800, height: 320 }}>
         <BarChart data={candles} margin={{ top: 10, right: 8, left: 8, bottom: 0 }}>
             <CartesianGrid strokeDasharray="3 3" stroke="#ffffff14" vertical={false} />
             <XAxis

--- a/src/views/ShroomHub/LiquidityBreakdown.tsx
+++ b/src/views/ShroomHub/LiquidityBreakdown.tsx
@@ -124,6 +124,10 @@ const LiquidityBreakdown = ({
                 </div>
             </SectionHeader>
 
+            {/* Each ResponsiveContainer below gets an initialDimension so it
+                doesn't log recharts' "width(-1) and height(-1)" warning on the
+                first render (its default is -1/-1); the ResizeObserver corrects
+                to this box's real size on mount. */}
             <div className={`w-full ${chartH}`}>
                 {loading && !pools.length ? (
                     <div className="flex h-full items-center justify-center text-sm text-white/50">
@@ -134,7 +138,7 @@ const LiquidityBreakdown = ({
                         No liquidity found.
                     </div>
                 ) : mode === 'pair' ? (
-                    <ResponsiveContainer width="100%" height="100%">
+                    <ResponsiveContainer width="100%" height="100%" initialDimension={{ width: 600, height: 288 }}>
                         <BarChart
                             layout="vertical"
                             data={pairRows}
@@ -171,7 +175,7 @@ const LiquidityBreakdown = ({
                         </BarChart>
                     </ResponsiveContainer>
                 ) : mode === 'venue' ? (
-                    <ResponsiveContainer width="100%" height="100%">
+                    <ResponsiveContainer width="100%" height="100%" initialDimension={{ width: 600, height: 288 }}>
                         <PieChart>
                             <Pie
                                 data={venueRows}
@@ -190,7 +194,7 @@ const LiquidityBreakdown = ({
                         </PieChart>
                     </ResponsiveContainer>
                 ) : (
-                    <ResponsiveContainer width="100%" height="100%">
+                    <ResponsiveContainer width="100%" height="100%" initialDimension={{ width: 600, height: 288 }}>
                         <BarChart
                             layout="vertical"
                             data={tokenRows}


### PR DESCRIPTION
## The warning

```
The width(-1) and height(-1) of chart should be greater than 0,
please check the style of container, or the props width(100%) and height(100%),
or add a minWidth(0) or minHeight(undefined) or use aspect(undefined)...
```

## Root cause

recharts 3.x logs this **once per mount** for any `ResponsiveContainer` with `width="100%" height="100%"`. It's not a container-sizing bug — it fires on the **first render**, before the `ResizeObserver` runs:

- `ResponsiveContainer`'s `initialDimension` defaults to `{ width: -1, height: -1 }`.
- On first render a `100%`/`100%` container computes `calculatedWidth = -1`, `calculatedHeight = -1` from that.
- The warn guard is `calculatedWidth > 0 || calculatedHeight > 0` → both `-1` → it warns.
- The observer then measures the real parent size on the next frame and re-renders fine.

This is exactly why `HoldersChart` (`height={200}` — a number) never warns: one dimension is already `> 0`.

## Fix

Pass a positive `initialDimension` to the four percentage-sized containers so the first render computes `> 0`. The `ResizeObserver` still corrects to the parent's real size on mount, so **responsiveness is unchanged** — this only affects the pre-measure first frame.

- `CandleChart` (landing page + ShroomHub markets panel)
- `LiquidityBreakdown` × 3 (ShroomHub — pair / venue / token modes)

## Verified

Called recharts' own `calculateChartDimensions` directly:

| initialDimension | calculated | willWarn |
|---|---|---|
| `-1 / -1` (default) | `-1 / -1` | **true** |
| `800 / 320` | `800 / 320` | false |
| `600 / 288` | `600 / 288` | false |

`tsc` ✓ · `eslint` ✓ · `vite build` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)