### PR TITLE
fix(shroom-hub): count distinct SHROOM holders (was double-counting bank + CW20)

### DIFF
--- a/src/views/ShroomHub/ecosystem.ts
+++ b/src/views/ShroomHub/ecosystem.ts
@@ -154,18 +154,24 @@ export const SAI_HOLDER_IDS = [SAI_DENOM];
 
 export const ECOSYSTEM_HOLDERS_QUERY = gql`
     query EcosystemHolders($shroom: [String!], $sai: [String!]) {
+        # SHROOM is tracked as two token rows — the CW20 and its bank (factory)
+        # denom — so a plain row count double-counts every wallet holding both.
+        # Count DISTINCT wallets instead. (balance table is unique per
+        # (wallet, token), so distinct wallet_id == the real holder count.)
         shroom_holders: wallet_tracker_balance_aggregate(
             where: { token_id: { _in: $shroom }, balance: { _gt: 0 } }
         ) {
             aggregate {
-                count
+                count(columns: [wallet_id], distinct: true)
             }
         }
+        # Distinct wallets here too, so it stays correct if SAI ever gains a
+        # wrapper denom (harmless for the current single-denom case).
         sai_holders: wallet_tracker_balance_aggregate(
             where: { token_id: { _in: $sai }, balance: { _gt: 0 } }
         ) {
             aggregate {
-                count
+                count(columns: [wallet_id], distinct: true)
             }
         }
         shroom_token: token_tracker_token(where: { address: { _in: $shroom } }) {


### PR DESCRIPTION
## Problem

The ShroomHub holder card showed **10,350**, which is inflated. SHROOM is tracked as **two** `token_tracker` rows — the CW20 (`inj1300…`) and its bank/factory denom (`factory/inj14ej…/inj1300…`). The card aggregated a **plain row count** over both:

```graphql
wallet_tracker_balance_aggregate(where: { token_id: { _in: $shroom }, balance: { _gt: 0 } }) {
  aggregate { count }
}
```

`wallet_tracker_balance` is unique per `(wallet, token)`, so a wallet holding SHROOM in both forms produces **two rows** → counted twice.

## Verified live (api.trippyinj.xyz)

| query | count |
|---|---|
| row count (the bug) | **10,350** |
| distinct wallets (the fix) | **9,092** |
| CW20 holders | 9,092 |
| bank/factory holders | 1,258 |

`9,092 + 1,258 = 10,350`, and distinct == CW20 count — i.e. **all 1,258 bank holders also hold the CW20**, so every one was double-counted. True holder count: **9,092**.

## Fix

`count(columns: [wallet_id], distinct: true)` on both the SHROOM and SAI holder aggregates (anon role already permits `wallet_id` + aggregations). SAI is single-denom so unaffected, but kept `distinct` for forward-safety if it ever gains a wrapper.

`tsc` ✓ · `vite build` ✓ · distinct query verified against live Hasura → 9,092.

🤖 Generated with [Claude Code](https://claude.com/claude-code)