### PR TITLE
Restyle token + NFT airdrop tools; fix NFT metadata load hang

### DIFF
--- a/src/components/Inputs/TokenSelect/index.tsx
+++ b/src/components/Inputs/TokenSelect/index.tsx
@@ -2,7 +2,10 @@ import { useState, useEffect } from 'react';
 import CreatableSelect from 'react-select/creatable';
 import IPFSImage from '../../App/IpfsImage';
 
-const TokenSelect = ({ options, selectedOption, setSelectedOption }: any) => {
+// `dark` opts into a dark-themed control (via the caller-supplied `styles`) and
+// drops the app default white-field `text-black` treatment. Off by default so
+// every existing usage keeps its current look.
+const TokenSelect = ({ options, selectedOption, setSelectedOption, styles, dark = false, placeholder }: any) => {
     const [showPasteButton, setShowPasteButton] = useState(!selectedOption);
 
     const handleChange = (option: any) => {
@@ -32,7 +35,14 @@ const TokenSelect = ({ options, selectedOption, setSelectedOption }: any) => {
     return (
         <div className='token-select-container mt-1'>
             {showPasteButton && (
-                <button onClick={() => { void handlePaste(); }} className="text-xs bg-slate-700 p-1 rounded-sm shadow-lg mb-1 mt-1">
+                <button
+                    onClick={() => { void handlePaste(); }}
+                    className={
+                        dark
+                            ? "mb-1.5 inline-flex items-center gap-1.5 rounded-lg border border-white/10 bg-white/5 px-3 py-1.5 text-xs font-medium text-slate-200 transition hover:bg-white/10 hover:text-white"
+                            : "text-xs bg-slate-700 p-1 rounded-sm shadow-lg mb-1 mt-1"
+                    }
+                >
                     Paste from clipboard
                 </button>
             )}
@@ -42,10 +52,11 @@ const TokenSelect = ({ options, selectedOption, setSelectedOption }: any) => {
                 value={selectedOption}
                 onChange={handleChange}
                 options={options}
-                className="token-select text-black"
+                className={dark ? "token-select" : "token-select text-black"}
+                styles={styles}
                 onCreateOption={handleCreate}
                 noOptionsMessage={() => null}
-                placeholder={"Search contract address"}
+                placeholder={placeholder ?? "Search contract address"}
                 formatCreateLabel={(inputValue) => `${inputValue}`}
                 formatOptionLabel={(data) => (
                     <div className='flex flex-row items-center'>

--- a/src/modules/tokenUtils.tsx
+++ b/src/modules/tokenUtils.tsx
@@ -1430,8 +1430,17 @@ class TokenUtils {
                     image = tokenUri;
                 } else {
                     // token_uri points at a metadata JSON — fetch it for the picture.
+                    // Guard with an abort-timeout: a slow/dead IPFS gateway (ipfs.io
+                    // rate-limits hard) must not hang the whole NFT load, because a
+                    // stalled fetch never rejects on its own.
                     try {
-                        const meta = await fetch(this.resolveIpfsUri(tokenUri)).then((r) => r.json());
+                        const controller = new AbortController();
+                        const timer = setTimeout(() => controller.abort(), 8000);
+                        const meta = await fetch(this.resolveIpfsUri(tokenUri), {
+                            signal: controller.signal,
+                        })
+                            .then((r) => r.json())
+                            .finally(() => clearTimeout(timer));
                         image = meta.image ?? meta.media ?? meta.image_uri ?? meta.animation_url ?? null;
                         name = name ?? meta.name ?? meta.title ?? null;
                     } catch {
@@ -1479,12 +1488,22 @@ class TokenUtils {
         if (tokenIds.length === 0) return [];
 
         // 2. Resolve thumbnails / names in small parallel batches (best-effort).
+        // Each resolve is raced against a hard timeout so a single hung query or
+        // gateway can never block the batch — a token that times out simply loads
+        // without a thumbnail, which selection doesn't need.
         const batchSize = 8;
         const out: { tokenId: string; name: string | null; image: string | null }[] = [];
         for (let i = 0; i < tokenIds.length; i += batchSize) {
             const batch = tokenIds.slice(i, i + batchSize);
             const resolved = await Promise.all(
-                batch.map((id) => this.resolveNftMetadata(collectionAddress, id)),
+                batch.map((id) =>
+                    Promise.race([
+                        this.resolveNftMetadata(collectionAddress, id),
+                        new Promise<{ tokenId: string; name: string | null; image: string | null }>(
+                            (resolve) => setTimeout(() => resolve({ tokenId: id, name: null, image: null }), 10000),
+                        ),
+                    ]),
+                ),
             );
             out.push(...resolved);
             setProgress(`loading metadata: ${Math.min(i + batchSize, tokenIds.length)} / ${tokenIds.length}`);

--- a/src/views/Airdrop/AirdropConfirmModal.tsx
+++ b/src/views/Airdrop/AirdropConfirmModal.tsx
@@ -25,6 +25,7 @@ import {
     planKey,
     recordChunkPaid,
 } from "./checkpoint";
+import { btnPrimary, btnGhost } from "./components/ui";
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -472,33 +473,41 @@ const AirdropConfirmModal = (props: {
     return (
         <>
             <div
-                className="justify-center items-center flex overflow-x-hidden overflow-y-auto fixed inset-0 z-50 outline-hidden focus:outline-hidden text-white text-sm"
+                className="fixed inset-0 z-50 flex items-center justify-center overflow-x-hidden overflow-y-auto p-4 text-sm text-white outline-hidden focus:outline-hidden"
             >
-                <div className="relative w-auto my-4 mx-auto max-w-4xl">
-                    <div className="border-0 rounded-lg shadow-lg relative flex flex-col w-full bg-gray-800 outline-hidden focus:outline-hidden">
-                        <div className="flex items-start justify-between p-4 border-b border-solid border-blueGray-900 rounded-t">
-                            <h3 className="text-xl font-semibold">
-                                Airdrop on {currentNetwork}
+                <div className="relative mx-auto my-4 w-full max-w-4xl">
+                    <div className="relative flex w-full flex-col rounded-2xl border border-white/10 bg-[#04141b] shadow-2xl shadow-black/50 outline-hidden focus:outline-hidden">
+                        <div className="flex items-center justify-between rounded-t-2xl border-b border-white/10 p-5">
+                            <h3 className="text-lg font-bold">
+                                Airdrop on <span className="capitalize text-trippyYellow">{currentNetwork}</span>
                             </h3>
-
+                            <button
+                                type="button"
+                                onClick={() => props.setShowModal(false)}
+                                className="text-slate-400 transition hover:text-white"
+                                aria-label="Close"
+                            >
+                                ✕
+                            </button>
                         </div>
 
-                        <div className="relative p-6 flex-auto">
+                        <div className="relative flex-auto p-5">
                             <div>
-                                <p>
-                                    Airdropping token <br />{props.tokenAddress}
-                                </p>
+                                <div className="rounded-lg border border-white/10 bg-slate-950/40 px-3 py-2 text-xs">
+                                    <span className="text-slate-400">Airdropping token</span>
+                                    <div className="mt-0.5 break-all font-mono text-slate-200">{props.tokenAddress}</div>
+                                </div>
 
-                                <div className="mt-4 grid grid-cols-2 md:grid-cols-3 gap-2">
-                                    <div className="rounded-md bg-slate-900 p-2">
+                                <div className="mt-4 grid grid-cols-2 gap-2 md:grid-cols-3">
+                                    <div className="rounded-lg border border-white/10 bg-slate-950/40 p-2.5">
                                         <div className="text-[11px] uppercase tracking-wide text-slate-400">Recipients</div>
                                         <div className="text-sm font-bold">{payable.length.toLocaleString()}</div>
                                     </div>
-                                    <div className="rounded-md bg-slate-900 p-2">
+                                    <div className="rounded-lg border border-white/10 bg-slate-950/40 p-2.5">
                                         <div className="text-[11px] uppercase tracking-wide text-slate-400">Total out</div>
                                         <div className="text-sm font-bold">{humanReadableAmount(totalOut)} {props.tokenSymbol ?? ""}</div>
                                     </div>
-                                    <div className="rounded-md bg-slate-900 p-2">
+                                    <div className="rounded-lg border border-white/10 bg-slate-950/40 p-2.5">
                                         <div className="text-[11px] uppercase tracking-wide text-slate-400">Transactions</div>
                                         <div className="text-sm font-bold">{txCount}{currentNetwork == "mainnet" ? " + fee" : ""}</div>
                                     </div>
@@ -511,64 +520,66 @@ const AirdropConfirmModal = (props: {
 
                                 {props.airdropDetails !== null && props.airdropDetails.length > 0 &&
                                     <div className="mt-5">
-                                        <div className="max-h-80 overflow-y-scroll overflow-x-auto">
-                                            <div>Total participants: {payable.length}</div>
-                                            <div className="text-xs">You should exclude addresses such as burn addresses, the pair contract etc..</div>
-                                            <div className="mt-2">
-                                                <table className="table-auto w-full">
-                                                    <thead className="text-white">
-                                                        <tr>
-
-                                                            <th className="px-4 py-2">
-                                                                Address
-                                                            </th>
-                                                            <th className="px-4 py-2">
-                                                                Airdrop
-                                                            </th>
-                                                            <th className="px-4 py-2">
-                                                                Percentage
-                                                            </th>
+                                        <div className="mb-2 text-xs text-slate-400">
+                                            Total participants:{" "}
+                                            <span className="font-bold text-white">{payable.length}</span> — exclude burn
+                                            addresses, pair contracts etc. on the previous screen.
+                                        </div>
+                                        <div className="max-h-80 overflow-x-auto overflow-y-auto rounded-xl border border-white/10">
+                                            <table className="w-full table-auto text-xs">
+                                                <thead className="sticky top-0 bg-[#04141b] text-left text-slate-400">
+                                                    <tr>
+                                                        <th className="px-4 py-2">Address</th>
+                                                        <th className="px-4 py-2">Airdrop</th>
+                                                        <th className="px-4 py-2">%</th>
+                                                    </tr>
+                                                </thead>
+                                                <tbody>
+                                                    {payable.map((holder: any, index: any) => (
+                                                        <tr key={index} className="border-b border-white/5 text-white transition hover:bg-white/5">
+                                                            <td className="whitespace-nowrap px-4 py-1.5">
+                                                                <a
+                                                                    className="transition hover:text-trippyYellow"
+                                                                    href={`https://explorer.injective.network/account/${holder.address}`}
+                                                                >
+                                                                    {holder.address}
+                                                                    {
+                                                                        (WALLET_LABELS as Record<string, any>)[holder.address] ? (
+                                                                            <span className={`${(WALLET_LABELS as Record<string, any>)[holder.address].bgColor} ${(WALLET_LABELS as Record<string, any>)[holder.address].textColor} ml-2`}>
+                                                                                {(WALLET_LABELS as Record<string, any>)[holder.address].label}
+                                                                            </span>
+                                                                        ) : null
+                                                                    }
+                                                                </a>
+                                                            </td>
+                                                            <td className="whitespace-nowrap px-4 py-1.5 font-medium text-trippyYellow">
+                                                                {Number(holder.amountToAirdrop).toFixed(props.tokenDecimals)}{" "}
+                                                            </td>
+                                                            <td className="px-4 py-1.5 text-slate-400">
+                                                                {Number(holder.percentToAirdrop).toFixed(2)}%
+                                                            </td>
                                                         </tr>
-                                                    </thead>
-                                                    <tbody>
-                                                        {payable.map((holder: any, index: any) => (
-                                                            <tr key={index} className="text-white border-b text-xs">
-                                                                <td className="px-6 py-1 whitespace-nowrap">
-                                                                    <a
-                                                                        className="hover:text-indigo-900"
-                                                                        href={`https://explorer.injective.network/account/${holder.address}`}
-                                                                    >
-                                                                        {holder.address}
-                                                                        {
-                                                                            (WALLET_LABELS as Record<string, any>)[holder.address] ? (
-                                                                                <span className={`${(WALLET_LABELS as Record<string, any>)[holder.address].bgColor} ${(WALLET_LABELS as Record<string, any>)[holder.address].textColor} ml-2`}>
-                                                                                    {(WALLET_LABELS as Record<string, any>)[holder.address].label}
-                                                                                </span>
-                                                                            ) : null
-                                                                        }
-                                                                    </a>
-                                                                </td>
-                                                                <td className="px-6 py-1">
-                                                                    {Number(holder.amountToAirdrop).toFixed(props.tokenDecimals)}{" "}
-                                                                </td>
-                                                                <td className="px-6 py-1">
-                                                                    {Number(holder.percentToAirdrop).toFixed(2)}%
-                                                                </td>
-                                                            </tr>
-                                                        ))}
-                                                    </tbody>
-                                                </table>
-                                            </div>
+                                                    ))}
+                                                </tbody>
+                                            </table>
                                         </div>
                                     </div>
                                 }
                             </div>
-                            {progress && <div className="mt-5">progress: {progress}</div>}
-                            {txLoading && <CircleLoader color="#36d7b7" className="mt-2 m-auto" />}
-                            {error && <div className="text-rose-600 mt-5">{error}</div>}
+                            {progress && (
+                                <div className="mt-5 text-sm text-slate-300">
+                                    <span className="text-slate-400">progress:</span> {progress}
+                                </div>
+                            )}
+                            {txLoading && <CircleLoader color="#f9d73f" className="mt-3 m-auto" />}
+                            {error && (
+                                <div className="mt-5 rounded-lg border border-rose-500/30 bg-rose-500/10 px-3 py-2 text-rose-300">
+                                    {error}
+                                </div>
+                            )}
                         </div>
                         {(estimatedTx !== null || hasProgress) &&
-                            <div className="mx-5 mb-2 rounded-md bg-slate-900 p-3">
+                            <div className="mx-5 mb-2 rounded-lg border border-white/10 bg-slate-950/40 p-3">
                                 <div className="flex flex-wrap gap-x-6 gap-y-1">
                                     <div>Recipients paid: <b>{paidCount}</b> / {payable.length}</div>
                                     {estimatedTx !== null &&
@@ -586,7 +597,7 @@ const AirdropConfirmModal = (props: {
                                         <button
                                             type="button"
                                             onClick={downloadReceipt}
-                                            className="ml-2 underline text-indigo-300"
+                                            className="ml-2 text-trippyYellow underline"
                                         >
                                             Download receipt
                                         </button>
@@ -595,23 +606,27 @@ const AirdropConfirmModal = (props: {
                             </div>
                         }
                         <div className="mx-5 text-xs text-slate-400">Each transaction retries up to 3 times with backoff. A failed transaction no longer aborts the whole airdrop — your progress is saved and you can retry the rest.</div>
-                        {currentNetwork == "mainnet" && (props.airdropDetails.length > 0) && <div className="m-5">
-                            Fee for airdrop: {props.shroomCost} shroom (cw20)<br />
-                            <a href="https://coinhall.org/injective/inj1m35kyjuegq7ruwgx787xm53e5wfwu6n5uadurl" className="underline text-sm">buy here</a>
-                            <br />
-                            <div className="mt-2">Fee payed: {feePayed ? "True" : "False"}</div>
-                        </div>
+                        {currentNetwork == "mainnet" && (props.airdropDetails.length > 0) &&
+                            <div className="mx-5 mt-3 flex items-center justify-between rounded-lg border border-white/10 bg-slate-950/40 px-3 py-2 text-sm">
+                                <span className="text-slate-400">
+                                    Fee: {props.shroomCost} SHROOM (cw20){" "}
+                                    <a href="https://coinhall.org/injective/inj1m35kyjuegq7ruwgx787xm53e5wfwu6n5uadurl" className="text-trippyYellow underline">buy here</a>
+                                </span>
+                                <span className={feePayed ? "font-bold text-emerald-400" : "font-bold text-slate-300"}>
+                                    {feePayed ? "Fee paid ✓" : "Fee unpaid"}
+                                </span>
+                            </div>
                         }
-                        <div className="flex items-center justify-end p-4 border-t border-solid border-blueGray-200 rounded-b">
+                        <div className="flex items-center justify-end gap-2 rounded-b-2xl border-t border-white/10 p-4">
                             <button
-                                className="text-slate-500 background-transparent font-bold uppercase px-6 py-2 text-sm outline-hidden focus:outline-hidden mr-1 mb-1 ease-linear transition-all duration-150"
+                                className={btnGhost}
                                 type="button"
                                 onClick={() => props.setShowModal(false)}
                             >
                                 Back
                             </button>
                             <button
-                                className="bg-gray-600 text-white active:bg-emerald-600 font-bold uppercase text-sm px-6 py-3 rounded-sm shadow-sm hover:shadow-lg outline-hidden focus:outline-hidden mr-1 mb-1 ease-linear transition-all duration-150 disabled:opacity-50 disabled:cursor-not-allowed"
+                                className={btnPrimary}
                                 type="button"
                                 disabled={txLoading}
                                 onClick={() => { void startAirdrop().then(() => console.log("done")).catch(e => {
@@ -627,7 +642,7 @@ const AirdropConfirmModal = (props: {
                     </div>
                 </div>
             </div>
-            <div className="opacity-25 fixed inset-0 z-40 bg-black"></div>
+            <div className="fixed inset-0 z-40 bg-black/60 backdrop-blur-sm"></div>
         </>
 
     )

--- a/src/views/Airdrop/components/AirdropListSection.tsx
+++ b/src/views/Airdrop/components/AirdropListSection.tsx
@@ -14,6 +14,8 @@ import RecipientSummary from "./RecipientSummary";
 import TopNLimiter from "./TopNLimiter";
 import MinAmountFilter from "./MinAmountFilter";
 import VoteFilter from "./VoteFilter";
+import { FiDownload } from "react-icons/fi";
+import { btnGhost } from "./ui";
 
 // Shared "you have a list — now refine and review it" section rendered by every
 // drop mode. Owns the wiring from UI controls to the pure distribution helpers.
@@ -70,20 +72,18 @@ const AirdropListSection = ({
     };
 
     return (
-        <div className="mt-5">
-            <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
+        <div className="mt-6 border-t border-white/10 pt-5">
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
                 <div className="text-sm text-slate-300">
                     Total participants:{" "}
-                    <span className="text-white font-bold">{summary.recipientCount.toLocaleString()}</span>
+                    <span className="font-bold text-white">{summary.recipientCount.toLocaleString()}</span>
                 </div>
-                <button
-                    onClick={exportCsv}
-                    className="bg-slate-700 hover:bg-slate-600 px-3 py-1 rounded-sm text-sm self-start"
-                >
+                <button onClick={exportCsv} className={`${btnGhost} self-start`}>
+                    <FiDownload size={13} />
                     Download CSV
                 </button>
             </div>
-            <div className="text-xs text-slate-400 mt-1">
+            <div className="mt-1 text-xs text-slate-400">
                 Exclude addresses you don't want to fund (burn wallets, pair/LP contracts, marketplaces…) by unchecking them or filtering.
             </div>
 

--- a/src/views/Airdrop/components/DistributionToggle.tsx
+++ b/src/views/Airdrop/components/DistributionToggle.tsx
@@ -16,7 +16,7 @@ const DistributionToggle = ({
 }) => {
     return (
         <div>
-            <label className="block font-bold text-white mb-1">Distribution</label>
+            <label className="mb-1 block text-sm font-bold text-white">Distribution</label>
             <div className="grid grid-cols-2 gap-2">
                 {OPTIONS.map((opt) => {
                     const active = value === opt.value;
@@ -25,10 +25,10 @@ const DistributionToggle = ({
                             key={opt.value}
                             type="button"
                             onClick={() => onChange(opt.value)}
-                            className={`rounded-md p-2 text-sm text-left border transition ${
+                            className={`rounded-lg border p-2.5 text-left text-sm transition ${
                                 active
-                                    ? "bg-slate-600 border-slate-400 text-white"
-                                    : "bg-slate-800 border-slate-700 text-slate-300 hover:bg-slate-700"
+                                    ? "border-trippyYellow/60 bg-trippyYellow/15 text-white"
+                                    : "border-white/10 bg-white/5 text-slate-300 hover:bg-white/10"
                             }`}
                         >
                             <div className="font-bold">{opt.label}</div>

--- a/src/views/Airdrop/components/HolderTable.tsx
+++ b/src/views/Airdrop/components/HolderTable.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from "react";
 import { WALLET_LABELS } from "../../../constants/walletLabels";
 import type { AirdropRecipient } from "../types";
 import { shortAddress } from "../format";
+import { btnGhost, inputBase } from "./ui";
 
 type WalletLabel = { label: string; bgColor: string; textColor: string };
 const LABELS = WALLET_LABELS as Record<string, WalletLabel | undefined>;
@@ -83,7 +84,7 @@ const HolderTable = ({
 
     return (
         <div className="mt-3">
-            <div className="flex flex-col sm:flex-row sm:items-center gap-2 mb-2">
+            <div className="mb-2 flex flex-col gap-2 sm:flex-row sm:items-center">
                 <input
                     type="text"
                     value={search}
@@ -92,29 +93,23 @@ const HolderTable = ({
                         setPage(0);
                     }}
                     placeholder="Search address…"
-                    className="bg-white text-black rounded-sm p-1 text-sm flex-1"
+                    className={`${inputBase} flex-1`}
                 />
                 {columns.include && onSetIncludeAll && (
-                    <div className="flex gap-2 text-xs">
-                        <button
-                            className="bg-slate-700 hover:bg-slate-600 px-2 py-1 rounded-sm"
-                            onClick={() => onSetIncludeAll(true)}
-                        >
+                    <div className="flex gap-2">
+                        <button className={btnGhost} onClick={() => onSetIncludeAll(true)}>
                             Select all
                         </button>
-                        <button
-                            className="bg-slate-700 hover:bg-slate-600 px-2 py-1 rounded-sm"
-                            onClick={() => onSetIncludeAll(false)}
-                        >
+                        <button className={btnGhost} onClick={() => onSetIncludeAll(false)}>
                             Select none
                         </button>
                     </div>
                 )}
             </div>
 
-            <div className="max-h-96 overflow-y-auto overflow-x-auto rounded-md border border-slate-700">
-                <table className="table-auto w-full text-xs">
-                    <thead className="text-white text-left sticky top-0 bg-slate-900">
+            <div className="max-h-96 overflow-y-auto overflow-x-auto rounded-xl border border-white/10">
+                <table className="w-full table-auto text-xs">
+                    <thead className="sticky top-0 bg-[#04141b] text-left text-slate-400">
                         <tr>
                             {columns.position && <th className="px-3 py-2">#</th>}
                             {columns.include && <th className="px-3 py-2">Include</th>}
@@ -141,19 +136,25 @@ const HolderTable = ({
                         {pageRows.map(({ r, originalIndex }) => {
                             const label = LABELS[r.address];
                             return (
-                                <tr key={r.address} className="text-white border-b border-slate-800">
-                                    {columns.position && <td className="px-3 py-1">{originalIndex + 1}</td>}
+                                <tr
+                                    key={r.address}
+                                    className="border-b border-white/5 text-white transition hover:bg-white/5"
+                                >
+                                    {columns.position && (
+                                        <td className="px-3 py-1.5 text-slate-500">{originalIndex + 1}</td>
+                                    )}
                                     {columns.include && (
-                                        <td className="px-3 py-1">
+                                        <td className="px-3 py-1.5">
                                             <input
                                                 type="checkbox"
+                                                className="h-4 w-4 accent-trippyYellow"
                                                 checked={r.includeInDrop || false}
                                                 onChange={() => onToggleInclude(r.address)}
                                             />
                                         </td>
                                     )}
-                                    <td className="px-3 py-1 whitespace-nowrap">
-                                        <a className="hover:text-indigo-300" href={`${explorerBase}/account/${r.address}`} target="_blank" rel="noreferrer">
+                                    <td className="whitespace-nowrap px-3 py-1.5">
+                                        <a className="transition hover:text-trippyYellow" href={`${explorerBase}/account/${r.address}`} target="_blank" rel="noreferrer">
                                             {shortAddress(r.address)}
                                             {label && (
                                                 <span className={`${label.bgColor} ${label.textColor} ml-2`}>
@@ -163,20 +164,20 @@ const HolderTable = ({
                                         </a>
                                     </td>
                                     {columns.vote && (
-                                        <td className="px-3 py-1">
+                                        <td className="px-3 py-1.5">
                                             {r.vote_option ? r.vote_option.replace("VOTE_OPTION_", "") : ""}
                                         </td>
                                     )}
                                     {columns.balance && (
-                                        <td className="px-3 py-1 whitespace-nowrap">
+                                        <td className="whitespace-nowrap px-3 py-1.5 text-slate-300">
                                             {Number(r.balance ?? 0).toFixed(sourceDecimals)}
                                             {sourceSymbol ? ` ${sourceSymbol}` : ""}
                                         </td>
                                     )}
-                                    <td className="px-3 py-1 whitespace-nowrap">
+                                    <td className="whitespace-nowrap px-3 py-1.5 font-medium text-trippyYellow">
                                         {Number(r.amountToAirdrop).toFixed(tokenDecimals)} {tokenSymbol}
                                     </td>
-                                    <td className="px-3 py-1">{Number(r.percentToAirdrop).toFixed(2)}%</td>
+                                    <td className="px-3 py-1.5 text-slate-400">{Number(r.percentToAirdrop).toFixed(2)}%</td>
                                 </tr>
                             );
                         })}
@@ -192,24 +193,24 @@ const HolderTable = ({
             </div>
 
             {pageCount > 1 && (
-                <div className="flex items-center justify-between mt-2 text-xs text-slate-300">
+                <div className="mt-3 flex items-center justify-between text-xs text-slate-400">
                     <span>
                         Showing {safePage * PAGE_SIZE + 1}–
                         {Math.min(filtered.length, safePage * PAGE_SIZE + PAGE_SIZE)} of {filtered.length}
                     </span>
-                    <div className="flex gap-2">
+                    <div className="flex items-center gap-2">
                         <button
-                            className="bg-slate-700 hover:bg-slate-600 disabled:opacity-40 px-2 py-1 rounded-sm"
+                            className={btnGhost}
                             disabled={safePage === 0}
                             onClick={() => setPage(safePage - 1)}
                         >
                             Prev
                         </button>
-                        <span className="px-1 py-1">
+                        <span className="px-1 text-slate-300">
                             {safePage + 1} / {pageCount}
                         </span>
                         <button
-                            className="bg-slate-700 hover:bg-slate-600 disabled:opacity-40 px-2 py-1 rounded-sm"
+                            className={btnGhost}
                             disabled={safePage >= pageCount - 1}
                             onClick={() => setPage(safePage + 1)}
                         >

--- a/src/views/Airdrop/components/MinAmountFilter.tsx
+++ b/src/views/Airdrop/components/MinAmountFilter.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { btnGhost, inputBase } from "./ui";
 
 // Drop recipients whose computed allocation is below a floor (e.g. dust from a
 // proportionate split to thousands of tiny holders) so gas isn't wasted on
@@ -16,10 +17,11 @@ const MinAmountFilter = ({
     const [value, setValue] = useState<string>("");
 
     return (
-        <div className="mt-2">
-            <label className="text-white inline-flex items-center gap-2 text-sm">
+        <div className="mt-3">
+            <label className="inline-flex items-center gap-2 text-sm text-white">
                 <input
                     type="checkbox"
+                    className="h-4 w-4 accent-trippyYellow"
                     checked={enabled}
                     onChange={() => {
                         const next = !enabled;
@@ -37,20 +39,17 @@ const MinAmountFilter = ({
                     <input
                         type="number"
                         min={0}
-                        className="bg-white text-black rounded-sm p-1 text-sm w-28"
+                        className={`${inputBase} w-28`}
                         value={value}
                         onChange={(e) => setValue(e.target.value)}
                         placeholder="min"
                     />
                     <span className="text-sm text-slate-300">{symbol}</span>
-                    <button
-                        className="bg-slate-700 hover:bg-slate-600 p-1 px-3 rounded-sm text-sm"
-                        onClick={() => onApply(Number(value) || 0)}
-                    >
+                    <button className={btnGhost} onClick={() => onApply(Number(value) || 0)}>
                         Apply
                     </button>
                     <button
-                        className="bg-slate-700 hover:bg-slate-600 p-1 px-3 rounded-sm text-sm"
+                        className={btnGhost}
                         onClick={() => {
                             setValue("");
                             onReset();

--- a/src/views/Airdrop/components/RecipientSummary.tsx
+++ b/src/views/Airdrop/components/RecipientSummary.tsx
@@ -2,7 +2,7 @@ import type { AirdropSummary } from "../distribution";
 import { humanReadableAmount } from "../format";
 
 const Stat = ({ label, value }: { label: string; value: string }) => (
-    <div className="rounded-md bg-slate-800 p-2">
+    <div className="rounded-lg border border-white/10 bg-slate-950/40 p-2.5">
         <div className="text-[11px] uppercase tracking-wide text-slate-400">{label}</div>
         <div className="text-sm font-bold text-white">{value}</div>
     </div>

--- a/src/views/Airdrop/components/SectionCard.tsx
+++ b/src/views/Airdrop/components/SectionCard.tsx
@@ -1,0 +1,35 @@
+import type { ReactNode } from "react";
+import { cardBase } from "./ui";
+
+// Numbered step container shared by the token- and NFT-airdrop flows: a brand
+// badge + title + optional subtitle, then the step body.
+const SectionCard = ({
+    step,
+    title,
+    subtitle,
+    children,
+    className = "",
+}: {
+    step?: ReactNode;
+    title: string;
+    subtitle?: ReactNode;
+    children: ReactNode;
+    className?: string;
+}) => (
+    <section className={`${cardBase} ${className}`}>
+        <header className="mb-4 flex items-start gap-3">
+            {step !== undefined && (
+                <span className="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-trippyYellow text-sm font-bold text-black">
+                    {step}
+                </span>
+            )}
+            <div>
+                <h2 className="text-base font-bold leading-tight text-white">{title}</h2>
+                {subtitle && <p className="mt-0.5 text-xs text-slate-400">{subtitle}</p>}
+            </div>
+        </header>
+        {children}
+    </section>
+);
+
+export default SectionCard;

--- a/src/views/Airdrop/components/TopNLimiter.tsx
+++ b/src/views/Airdrop/components/TopNLimiter.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { btnGhost, inputBase } from "./ui";
 
 // "Limit to top N wallets by holdings" control. Was duplicated 4× inline; now
 // self-contained — owns its toggle + value and reports apply/reset upward.
@@ -21,10 +22,11 @@ const TopNLimiter = ({
     }, [enabled]);
 
     return (
-        <div className="mt-2">
-            <label className="text-white inline-flex items-center gap-2 text-sm">
+        <div className="mt-3">
+            <label className="inline-flex items-center gap-2 text-sm text-white">
                 <input
                     type="checkbox"
+                    className="h-4 w-4 accent-trippyYellow"
                     checked={enabled}
                     onChange={() => setEnabled((e) => !e)}
                 />
@@ -35,19 +37,16 @@ const TopNLimiter = ({
                     <input
                         type="number"
                         min={1}
-                        className="bg-white text-black rounded-sm p-1 text-sm w-24"
+                        className={`${inputBase} w-28`}
                         value={value}
                         onChange={(e) => setValue(e.target.value)}
                         placeholder="e.g. 100"
                     />
-                    <button
-                        className="bg-slate-700 hover:bg-slate-600 p-1 px-3 rounded-sm text-sm"
-                        onClick={() => onApply(Number(value) || 0)}
-                    >
+                    <button className={btnGhost} onClick={() => onApply(Number(value) || 0)}>
                         Apply
                     </button>
                     <button
-                        className="bg-slate-700 hover:bg-slate-600 p-1 px-3 rounded-sm text-sm"
+                        className={btnGhost}
                         onClick={() => {
                             setValue("");
                             onReset();

--- a/src/views/Airdrop/components/VoteFilter.tsx
+++ b/src/views/Airdrop/components/VoteFilter.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import type { VoteFilters, VoteOption } from "../types";
+import { btnGhost } from "./ui";
 
 const OPTIONS: { key: VoteOption; label: string }[] = [
     { key: "VOTE_OPTION_YES", label: "YES" },
@@ -27,10 +28,11 @@ const VoteFilter = ({
     const [filters, setFilters] = useState<VoteFilters>({ ...ALL_TRUE });
 
     return (
-        <div className="mt-2">
-            <label className="text-white inline-flex items-center gap-2 text-sm">
+        <div className="mt-3">
+            <label className="inline-flex items-center gap-2 text-sm text-white">
                 <input
                     type="checkbox"
+                    className="h-4 w-4 accent-trippyYellow"
                     checked={enabled}
                     onChange={() => {
                         const next = !enabled;
@@ -47,9 +49,10 @@ const VoteFilter = ({
                 <div className="mt-2">
                     <div className="flex flex-wrap gap-3">
                         {OPTIONS.map(({ key, label }) => (
-                            <label key={key} className="inline-flex items-center gap-1 text-sm font-bold text-white">
+                            <label key={key} className="inline-flex items-center gap-1.5 text-sm font-medium text-white">
                                 <input
                                     type="checkbox"
+                                    className="h-4 w-4 accent-trippyYellow"
                                     checked={filters[key]}
                                     onChange={() =>
                                         setFilters((f) => ({ ...f, [key]: !f[key] }))
@@ -59,15 +62,12 @@ const VoteFilter = ({
                             </label>
                         ))}
                     </div>
-                    <div className="mt-2 flex gap-2">
-                        <button
-                            className="bg-slate-700 hover:bg-slate-600 p-1 px-3 rounded-sm text-sm"
-                            onClick={() => onApply(filters)}
-                        >
+                    <div className="mt-3 flex gap-2">
+                        <button className={btnGhost} onClick={() => onApply(filters)}>
                             Apply
                         </button>
                         <button
-                            className="bg-slate-700 hover:bg-slate-600 p-1 px-3 rounded-sm text-sm"
+                            className={btnGhost}
                             onClick={() => {
                                 setFilters({ ...ALL_TRUE });
                                 onReset();

--- a/src/views/Airdrop/components/ui.ts
+++ b/src/views/Airdrop/components/ui.ts
@@ -1,0 +1,76 @@
+import type { GroupBase, StylesConfig } from "react-select";
+
+// Shared visual primitives for the airdrop tool. Centralising the class strings
+// here keeps every button/input/card on one consistent design language instead
+// of the grab-bag of slate/gray shades and radii the view grew organically.
+
+// Buttons — three intents:
+//  • primary  → brand-yellow forward CTA (get info / generate list / review)
+//  • secondary→ neutral action (nav links, preliminary fetches)
+//  • ghost    → small inline controls (apply / reset / max / pagination)
+export const btnPrimary =
+    "inline-flex items-center justify-center gap-2 rounded-xl bg-trippyYellow px-4 py-2.5 text-sm font-bold text-black shadow-lg shadow-trippyYellow/10 transition hover:brightness-105 active:brightness-95 disabled:cursor-not-allowed disabled:opacity-50";
+
+export const btnSecondary =
+    "inline-flex items-center justify-center gap-2 rounded-xl border border-white/10 bg-white/5 px-4 py-2.5 text-sm font-medium text-white transition hover:border-white/20 hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-50";
+
+export const btnGhost =
+    "inline-flex items-center justify-center gap-1.5 rounded-lg border border-white/10 bg-white/5 px-3 py-1.5 text-xs font-medium text-slate-200 transition hover:bg-white/10 hover:text-white disabled:cursor-not-allowed disabled:opacity-40";
+
+// Dark form control that reads as native to the teal page background. Inputs
+// here deliberately avoid the app-wide `text-black` (white-field) treatment.
+export const inputBase =
+    "w-full rounded-lg border border-white/10 bg-slate-950/60 px-3 py-2 text-sm text-white placeholder:text-slate-500 outline-none transition focus:border-trippyYellow/60 focus:ring-1 focus:ring-trippyYellow/40 disabled:cursor-not-allowed disabled:opacity-50";
+
+export const cardBase =
+    "rounded-2xl border border-white/10 bg-white/[0.03] p-5 shadow-lg shadow-black/20";
+
+export const labelBase = "block text-sm font-bold text-white";
+
+// Dark theme for the inline react-select instances used in this view so they
+// match the dark inputs instead of the library's default white control.
+export const darkSelectStyles: StylesConfig<any, boolean, GroupBase<any>> = {
+    control: (base, state) => ({
+        ...base,
+        backgroundColor: "rgba(2,6,23,0.6)",
+        borderColor: state.isFocused ? "rgba(249,215,63,0.6)" : "rgba(255,255,255,0.1)",
+        borderRadius: 10,
+        minHeight: 42,
+        boxShadow: state.isFocused ? "0 0 0 1px rgba(249,215,63,0.4)" : "none",
+        ":hover": { borderColor: "rgba(255,255,255,0.2)" },
+    }),
+    menu: (base) => ({
+        ...base,
+        backgroundColor: "#04141b",
+        border: "1px solid rgba(255,255,255,0.1)",
+        borderRadius: 10,
+        overflow: "hidden",
+        zIndex: 30,
+    }),
+    menuList: (base) => ({ ...base, padding: 4 }),
+    option: (base, state) => ({
+        ...base,
+        backgroundColor: state.isSelected
+            ? "rgba(249,215,63,0.15)"
+            : state.isFocused
+              ? "rgba(255,255,255,0.06)"
+              : "transparent",
+        color: "#fff",
+        borderRadius: 8,
+        cursor: "pointer",
+        ":active": { backgroundColor: "rgba(249,215,63,0.2)" },
+    }),
+    singleValue: (base) => ({ ...base, color: "#fff" }),
+    placeholder: (base) => ({ ...base, color: "#64748b" }),
+    input: (base) => ({ ...base, color: "#fff" }),
+    indicatorSeparator: (base) => ({ ...base, backgroundColor: "rgba(255,255,255,0.1)" }),
+    dropdownIndicator: (base) => ({ ...base, color: "#64748b", ":hover": { color: "#fff" } }),
+    clearIndicator: (base) => ({ ...base, color: "#64748b", ":hover": { color: "#fff" } }),
+    groupHeading: (base) => ({
+        ...base,
+        color: "#64748b",
+        textTransform: "uppercase",
+        fontSize: 11,
+        letterSpacing: "0.05em",
+    }),
+};

--- a/src/views/Airdrop/index.tsx
+++ b/src/views/Airdrop/index.tsx
@@ -26,6 +26,17 @@ import type { AirdropRecipient, DistMode, DropMode } from "./types";
 import DistributionToggle from "./components/DistributionToggle";
 import AirdropListSection from "./components/AirdropListSection";
 import { withShroomMetadata } from "../../modules/shroomTokenMeta";
+import { PiParachuteBold } from "react-icons/pi";
+import SectionCard from "./components/SectionCard";
+import {
+    btnPrimary,
+    btnSecondary,
+    btnGhost,
+    inputBase,
+    cardBase,
+    labelBase,
+    darkSelectStyles,
+} from "./components/ui";
 
 const SHROOM_PAIR_ADDRESS = "inj1m35kyjuegq7ruwgx787xm53e5wfwu6n5uadurl";
 const STAKING_CONTRACT_ADDRESS = "inj1gtze7qm07nky47n7mwgj4zatf2s77xqvh3k2n8";
@@ -40,7 +51,7 @@ const MITO_EXCLUDED_WALLETS = [
 
 const DROP_MODE_OPTIONS: { value: DropMode; label: string }[] = [
     { value: "NFT", label: "NFT community" },
-    { value: "TOKEN", label: "Token holders" },
+    { value: "TOKEN", label: "Token or liquidity (LP) token holders" },
     { value: "CSV", label: "Custom CSV file upload" },
     { value: "GOV", label: "Proposal Voters" },
     { value: "MITO", label: "Mito Vault Holders / Stakers" },
@@ -741,30 +752,29 @@ const Airdrop = () => {
                     <div className="flex justify-center items-center min-h-full">
                         <div className="w-full max-w-(--breakpoint-lg) px-2">
                             {connectedAddress ? (
-                                <div>
-                                    <div className="text-center text-white mb-2">
-                                        <div className="text-3xl font-magic">New Airdrop</div>
-                                        <div className="text-sm">on Injective {currentNetwork}</div>
+                                <div className="space-y-5">
+                                    <div className="text-center text-white">
+                                        <PiParachuteBold className="mx-auto mb-2 text-trippyYellow" size={34} />
+                                        <div className="font-magic text-3xl">New Airdrop</div>
+                                        <div className="text-sm text-slate-400">
+                                            on Injective{" "}
+                                            <span className="capitalize text-trippyYellow">{currentNetwork}</span>
+                                        </div>
                                     </div>
-                                    <div className="flex flex-col sm:flex-row gap-2 my-4">
+                                    <div className="flex flex-col gap-2 sm:flex-row">
                                         <Link to="/nft-airdrop" className="flex-1">
-                                            <div className="bg-slate-800 hover:bg-slate-700 p-2 rounded-sm text-center text-sm">
-                                                Airdrop NFTs instead →
-                                            </div>
+                                            <div className={`${btnSecondary} w-full`}>Airdrop NFTs instead →</div>
                                         </Link>
                                         <Link to="/airdrop-history" className="flex-1">
-                                            <div className="bg-slate-800 hover:bg-slate-700 p-2 rounded-sm text-center text-sm">
-                                                View airdrop history
-                                            </div>
+                                            <div className={`${btnSecondary} w-full`}>View airdrop history</div>
                                         </Link>
                                     </div>
 
                                     {/* Step 1 — token to airdrop */}
-                                    <div className="border p-4 rounded-lg border-slate-700">
-                                        <label className="font-bold text-base text-white mb-2">
-                                            1. Token to airdrop (contract address / denom)
-                                        </label>
+                                    <SectionCard step={1} title="Token to airdrop" subtitle="Contract address / denom">
                                         <TokenSelect
+                                            dark
+                                            styles={darkSelectStyles}
                                             options={[
                                                 {
                                                     label: "TOKENS",
@@ -785,35 +795,48 @@ const Airdrop = () => {
                                             <button
                                                 disabled={loading}
                                                 onClick={getTokenInfo}
-                                                className="bg-gray-800 hover:bg-gray-700 rounded-lg p-2 w-full text-white mt-4 shadow-lg"
+                                                className={`${btnPrimary} mt-4 w-full`}
                                             >
                                                 Get token info
                                             </button>
                                         )}
 
-                                        <div className="flex flex-col md:flex-row justify-between">
+                                        <div className="mt-5 flex flex-col justify-between gap-4 md:flex-row">
                                             {tokenInfo && (
-                                                <div className="mt-5 text-sm text-white">
-                                                    <div>name: {tokenInfo.name}</div>
-                                                    <div>symbol: {tokenInfo.symbol}</div>
-                                                    <div>decimals: {tokenInfo.decimals}</div>
-                                                    {tokenInfo.description && <div>description: {tokenInfo.description}</div>}
+                                                <div className="flex-1 space-y-1.5 text-sm text-white">
+                                                    <div>
+                                                        <span className="text-slate-400">name:</span> {tokenInfo.name}
+                                                    </div>
+                                                    <div>
+                                                        <span className="text-slate-400">symbol:</span> {tokenInfo.symbol}
+                                                    </div>
+                                                    <div>
+                                                        <span className="text-slate-400">decimals:</span>{" "}
+                                                        {tokenInfo.decimals}
+                                                    </div>
+                                                    {tokenInfo.description && (
+                                                        <div>
+                                                            <span className="text-slate-400">description:</span>{" "}
+                                                            {tokenInfo.description}
+                                                        </div>
+                                                    )}
                                                     {tokenInfo.total_supply && (
                                                         <div>
-                                                            total supply:{" "}
+                                                            <span className="text-slate-400">total supply:</span>{" "}
                                                             {tokenInfo.total_supply / Math.pow(10, tokenInfo.decimals)}
                                                         </div>
                                                     )}
                                                 </div>
                                             )}
                                             {!pairMarketing && tokenInfo && tokenInfo.logo && (
-                                                <div className="mt-5 text-sm text-white">
+                                                <div className="text-sm text-white">
                                                     <IPFSImage
                                                         width={100}
                                                         className={"mb-2 rounded-lg"}
                                                         ipfsPath={tokenInfo.logo}
                                                     />
                                                     <a
+                                                        className="text-slate-300 transition hover:text-trippyYellow"
                                                         href={`https://${
                                                             currentNetwork === "testnet" ? "testnet." : ""
                                                         }explorer.injective.network/account/${tokenInfo.admin}`}
@@ -832,7 +855,7 @@ const Airdrop = () => {
                                                 </div>
                                             )}
                                             {pairMarketing && pairMarketing.logo && (
-                                                <div className="mt-5 text-sm text-white">
+                                                <div className="text-sm text-white">
                                                     <img
                                                         src={pairMarketing.logo.url}
                                                         style={{ width: 50, height: 50 }}
@@ -857,23 +880,24 @@ const Airdrop = () => {
                                             )}
                                         </div>
                                         {tokenInfo && (
-                                            <div>
-                                                <div className="my-2">
-                                                    Your balance: {balance} {tokenInfo.symbol}
+                                            <div className="mt-5">
+                                                <div className="mb-3 flex items-center justify-between rounded-lg border border-white/10 bg-slate-950/40 px-3 py-2 text-sm">
+                                                    <span className="text-slate-400">Your balance</span>
+                                                    <span className="font-bold text-white">
+                                                        {balance} {tokenInfo.symbol}
+                                                    </span>
                                                 </div>
                                                 <div>
-                                                    <label className="text-base font-bold text-white mb-1">
-                                                        Amount to airdrop
-                                                    </label>
+                                                    <label className={`${labelBase} mb-1`}>Amount to airdrop</label>
                                                     <div className="flex items-center gap-2">
                                                         <input
                                                             type="number"
-                                                            className="bg-white text-black w-full rounded-sm p-1 text-sm"
+                                                            className={inputBase}
                                                             onChange={(e) => setBalanceToDrop(e.target.value)}
                                                             value={balanceToDrop}
                                                         />
                                                         <button
-                                                            className="bg-slate-700 hover:bg-slate-600 px-3 py-1 rounded-sm text-sm whitespace-nowrap"
+                                                            className={`${btnGhost} whitespace-nowrap`}
                                                             onClick={() => setBalanceToDrop(String(balance))}
                                                         >
                                                             Max
@@ -882,15 +906,15 @@ const Airdrop = () => {
                                                 </div>
                                             </div>
                                         )}
-                                    </div>
+                                    </SectionCard>
 
                                     {/* Step 2 — drop mode */}
                                     {tokenInfo && (
-                                        <div className="mt-5 border p-4 rounded-lg border-slate-700">
-                                            <div className="space-y-2 mb-5">
-                                                <label className="text-base font-bold text-white">2. Drop Mode</label>
+                                        <SectionCard step={2} title="Drop Mode">
+                                            <div className="mb-5 space-y-2">
+                                                <label className={labelBase}>Who receives the drop?</label>
                                                 <Select
-                                                    className="text-black"
+                                                    styles={darkSelectStyles}
                                                     value={dropMode}
                                                     onChange={setDropMode as any}
                                                     options={DROP_MODE_OPTIONS}
@@ -900,10 +924,10 @@ const Airdrop = () => {
                                             {dropMode.value === "NFT" && (
                                                 <div>
                                                     <div className="space-y-2">
-                                                        <label className="text-base font-bold text-white">
-                                                            NFT collection address
-                                                        </label>
+                                                        <label className={labelBase}>NFT collection address</label>
                                                         <TokenSelect
+                                                            dark
+                                                            styles={darkSelectStyles}
                                                             options={[
                                                                 { label: "CW404", options: CW404_TOKENS },
                                                                 { label: "NFT", options: NFT_COLLECTIONS },
@@ -912,21 +936,20 @@ const Airdrop = () => {
                                                             setSelectedOption={setNftCollection}
                                                         />
                                                     </div>
-                                                    <div className="mt-4 mb-2">
+                                                    <div className="mb-2 mt-4">
                                                         <DistributionToggle value={distMode} onChange={setDistMode} />
                                                     </div>
                                                     <button
                                                         disabled={loading}
                                                         onClick={() => { void getNftCollection(); }}
-                                                        className="bg-gray-800 hover:bg-gray-700 rounded-lg p-2 w-full text-white mt-4 shadow-lg"
+                                                        className={`${btnPrimary} mt-4 w-full`}
                                                     >
                                                         Get collection holders
                                                     </button>
                                                     {nftCollectionInfo && (
-                                                        <div className="text-sm mt-5">
-                                                            Collection Name: {nftCollectionInfo.name}
-                                                            <br />
-                                                            Collection Symbol: {nftCollectionInfo.symbol}
+                                                        <div className="mt-4 rounded-lg border border-white/10 bg-slate-950/40 px-3 py-2 text-sm text-white">
+                                                            <span className="text-slate-400">Collection:</span>{" "}
+                                                            {nftCollectionInfo.name} ({nftCollectionInfo.symbol})
                                                         </div>
                                                     )}
                                                     {airdropDetails.length > 0 && (
@@ -949,9 +972,18 @@ const Airdrop = () => {
 
                                             {dropMode.value === "TOKEN" && (
                                                 <div>
-                                                    <div className="mt-4 space-y-2">
-                                                        <label className="block text-white">airdrop to holders of token</label>
+                                                    <div className="space-y-2">
+                                                        <label className={labelBase}>
+                                                            Airdrop to holders of a token or liquidity (LP) token
+                                                        </label>
+                                                        <p className="text-xs text-slate-400">
+                                                            Pick a token to drop to its holders, or a{" "}
+                                                            <span className="text-slate-200">liquidity (LP) token</span>{" "}
+                                                            to drop to that pool's liquidity providers.
+                                                        </p>
                                                         <TokenSelect
+                                                            dark
+                                                            styles={darkSelectStyles}
                                                             options={[
                                                                 {
                                                                     label: "Tokens",
@@ -964,7 +996,7 @@ const Airdrop = () => {
                                                                         })),
                                                                 },
                                                                 {
-                                                                    label: "LIQUIDITY tokens",
+                                                                    label: "Liquidity (LP) tokens — drop to LPs",
                                                                     options: pools
                                                                         .filter((p) => p.liquidity_token !== null)
                                                                         .sort((a, b) => {
@@ -988,13 +1020,13 @@ const Airdrop = () => {
                                                             setSelectedOption={setAirdropTokenAddress}
                                                         />
                                                     </div>
-                                                    <div className="mt-4 mb-2">
+                                                    <div className="mb-2 mt-4">
                                                         <DistributionToggle value={distMode} onChange={setDistMode} />
                                                     </div>
                                                     <button
                                                         disabled={loading}
                                                         onClick={() => { void getTokenHolders(); }}
-                                                        className="bg-gray-800 hover:bg-gray-700 rounded-lg p-2 w-full text-white mt-4 shadow-lg"
+                                                        className={`${btnPrimary} mt-4 w-full`}
                                                     >
                                                         Generate airdrop list
                                                     </button>
@@ -1020,21 +1052,20 @@ const Airdrop = () => {
                                             {dropMode.value === "CSV" && (
                                                 <div>
                                                     {airdropDetails.length === 0 && (
-                                                        <div className="text-sm my-2">
-                                                            CSV file like:
-                                                            <br />
-                                                            address,amount
-                                                            <br />
-                                                            inj...,10.1
-                                                            <br />
-                                                            inj...,20.2
+                                                        <div className="mb-3">
+                                                            <div className="mb-1.5 text-xs text-slate-400">
+                                                                Upload a CSV shaped like:
+                                                            </div>
+                                                            <pre className="overflow-x-auto rounded-lg border border-white/10 bg-slate-950/60 p-3 text-xs text-slate-300">
+address,amount{"\n"}inj...,10.1{"\n"}inj...,20.2
+                                                            </pre>
                                                         </div>
                                                     )}
                                                     <input
                                                         type="file"
                                                         accept=".csv"
                                                         onChange={(e) => { void handleFileUpload(e); }}
-                                                        className="text-white text-sm file:mr-3 file:rounded-sm file:border-0 file:bg-slate-700 file:px-3 file:py-1 file:text-white hover:file:bg-slate-600"
+                                                        className="text-sm text-slate-300 file:mr-3 file:cursor-pointer file:rounded-lg file:border file:border-white/10 file:bg-white/5 file:px-3 file:py-1.5 file:text-xs file:font-medium file:text-slate-200 hover:file:bg-white/10"
                                                     />
                                                     {csvInvalidRows.length > 0 && (
                                                         <div className="text-amber-400 text-xs mt-2">
@@ -1064,37 +1095,37 @@ const Airdrop = () => {
                                             {dropMode.value === "GOV" && (
                                                 <div>
                                                     <div className="space-y-2">
-                                                        <label className="text-base font-bold text-white mr-2">
-                                                            Governance Proposal #
-                                                        </label>
+                                                        <label className={labelBase}>Governance proposal #</label>
                                                         <input
-                                                            className="bg-white text-black rounded-sm p-1"
+                                                            className={`${inputBase} sm:max-w-xs`}
                                                             value={proposalNumber}
                                                             onChange={(e) => setProposalNumber(e.target.value)}
                                                         />
                                                     </div>
-                                                    <div className="space-y-2">
-                                                        <label className="text-base font-bold text-white mr-2">Block height</label>
-                                                        <input
-                                                            disabled={attemptFindBlock === true}
-                                                            className="bg-white text-black rounded-sm p-1 disabled:bg-slate-400"
-                                                            value={blockHeight}
-                                                            onChange={(e) => setBlockHeight(Number(e.target.value))}
-                                                        />
-                                                        <label className="text-base font-bold text-white mx-2">OR</label>
-                                                        <input
-                                                            type="checkbox"
-                                                            className="text-black"
-                                                            checked={attemptFindBlock === true}
-                                                            onChange={() => setAttemptFindBlock(!attemptFindBlock)}
-                                                        />
-                                                        <label className="text-base font-bold text-white mx-2">
-                                                            attempt to auto find block
-                                                        </label>
+                                                    <div className="mt-4 space-y-2">
+                                                        <label className={labelBase}>Block height</label>
+                                                        <div className="flex flex-wrap items-center gap-3">
+                                                            <input
+                                                                disabled={attemptFindBlock === true}
+                                                                className={`${inputBase} sm:max-w-xs`}
+                                                                value={blockHeight}
+                                                                onChange={(e) => setBlockHeight(Number(e.target.value))}
+                                                            />
+                                                            <span className="text-xs font-bold uppercase text-slate-500">or</span>
+                                                            <label className="inline-flex items-center gap-2 text-sm font-medium text-white">
+                                                                <input
+                                                                    type="checkbox"
+                                                                    className="h-4 w-4 accent-trippyYellow"
+                                                                    checked={attemptFindBlock === true}
+                                                                    onChange={() => setAttemptFindBlock(!attemptFindBlock)}
+                                                                />
+                                                                auto-find block
+                                                            </label>
+                                                        </div>
                                                     </div>
                                                     <button
                                                         onClick={() => { void getPropVoters(); }}
-                                                        className="bg-gray-800 hover:bg-gray-700 rounded-lg p-2 w-full text-white mt-6 shadow-lg"
+                                                        className={`${btnPrimary} mt-6 w-full`}
                                                     >
                                                         Get voters
                                                     </button>
@@ -1118,18 +1149,16 @@ const Airdrop = () => {
                                             {dropMode.value === "BUYBACK" && (
                                                 <div>
                                                     {currentNetwork !== "mainnet" ? (
-                                                        <div className="text-amber-400 text-sm">
+                                                        <div className="rounded-lg border border-amber-400/30 bg-amber-400/10 px-3 py-2 text-sm text-amber-300">
                                                             Community BuyBack is a mainnet-only program. Switch to
                                                             mainnet to load round participants.
                                                         </div>
                                                     ) : (
                                                         <>
                                                             <div className="space-y-2">
-                                                                <label className="text-base font-bold text-white">
-                                                                    BuyBack round
-                                                                </label>
+                                                                <label className={labelBase}>BuyBack round</label>
                                                                 <Select
-                                                                    className="text-black"
+                                                                    styles={darkSelectStyles}
                                                                     value={buybackRound}
                                                                     onChange={setBuybackRound}
                                                                     options={buybackRounds}
@@ -1145,7 +1174,7 @@ const Airdrop = () => {
                                                                     buyback round.
                                                                 </div>
                                                             </div>
-                                                            <div className="mt-4 mb-2">
+                                                            <div className="mb-2 mt-4">
                                                                 <DistributionToggle
                                                                     value={distMode}
                                                                     onChange={setDistMode}
@@ -1156,7 +1185,7 @@ const Airdrop = () => {
                                                                 onClick={() => {
                                                                     void getBuybackParticipants();
                                                                 }}
-                                                                className="bg-gray-800 hover:bg-gray-700 rounded-lg p-2 w-full text-white mt-2 shadow-lg disabled:opacity-50"
+                                                                className={`${btnPrimary} mt-2 w-full`}
                                                             >
                                                                 Get participants
                                                             </button>
@@ -1188,15 +1217,15 @@ const Airdrop = () => {
                                                     <button
                                                         disabled={loading}
                                                         onClick={() => { void getMitoMarketList(); }}
-                                                        className="bg-gray-800 hover:bg-gray-700 rounded-lg p-2 w-full text-white shadow-lg"
+                                                        className={`${btnSecondary} w-full`}
                                                     >
                                                         Get vault list
                                                     </button>
                                                     {mitoVaults.length > 0 && (
-                                                        <div className="mt-2">
-                                                            <label>Select Vault</label>
+                                                        <div className="mt-4 space-y-2">
+                                                            <label className={labelBase}>Select vault</label>
                                                             <Select
-                                                                className="text-black"
+                                                                styles={darkSelectStyles}
                                                                 value={selectedMitoVault}
                                                                 options={mitoVaults}
                                                                 onChange={setSelectedMitoVault}
@@ -1205,19 +1234,19 @@ const Airdrop = () => {
                                                     )}
                                                     {selectedMitoVault !== null && (
                                                         <div className="mt-4">
-                                                            <div className="mt-4 mb-2">
+                                                            <div className="mb-2 mt-4">
                                                                 <DistributionToggle value={distMode} onChange={setDistMode} />
                                                             </div>
-                                                            <div className="mt-4 mb-2">
-                                                                <label className="text-base font-bold text-white">Balance type</label>
-                                                                <div className="grid grid-cols-2 gap-2 mt-1">
+                                                            <div className="mb-2 mt-4">
+                                                                <label className={`${labelBase} mb-1`}>Balance type</label>
+                                                                <div className="mt-1 grid grid-cols-2 gap-2">
                                                                     <button
                                                                         type="button"
                                                                         onClick={() => setMitoHolderType("non-stake")}
-                                                                        className={`rounded-md p-2 text-sm border transition ${
+                                                                        className={`rounded-lg border p-2 text-sm font-medium transition ${
                                                                             mitoHolderType === "non-stake"
-                                                                                ? "bg-slate-600 border-slate-400 text-white"
-                                                                                : "bg-slate-800 border-slate-700 text-slate-300 hover:bg-slate-700"
+                                                                                ? "border-trippyYellow/60 bg-trippyYellow/15 text-white"
+                                                                                : "border-white/10 bg-white/5 text-slate-300 hover:bg-white/10"
                                                                         }`}
                                                                     >
                                                                         total balance
@@ -1225,10 +1254,10 @@ const Airdrop = () => {
                                                                     <button
                                                                         type="button"
                                                                         onClick={() => setMitoHolderType("stake")}
-                                                                        className={`rounded-md p-2 text-sm border transition ${
+                                                                        className={`rounded-lg border p-2 text-sm font-medium transition ${
                                                                             mitoHolderType === "stake"
-                                                                                ? "bg-slate-600 border-slate-400 text-white"
-                                                                                : "bg-slate-800 border-slate-700 text-slate-300 hover:bg-slate-700"
+                                                                                ? "border-trippyYellow/60 bg-trippyYellow/15 text-white"
+                                                                                : "border-white/10 bg-white/5 text-slate-300 hover:bg-white/10"
                                                                         }`}
                                                                     >
                                                                         staked balance only
@@ -1241,7 +1270,7 @@ const Airdrop = () => {
                                                                         selectedMitoVault.value.matchingVault.contractAddress,
                                                                     );
                                                                 }}
-                                                                className="bg-gray-800 hover:bg-gray-700 rounded-lg p-2 w-full text-white shadow-lg"
+                                                                className={`${btnPrimary} w-full`}
                                                             >
                                                                 Generate airdrop list
                                                             </button>
@@ -1264,44 +1293,56 @@ const Airdrop = () => {
                                                     )}
                                                 </div>
                                             )}
-                                        </div>
+                                        </SectionCard>
                                     )}
                                 </div>
                             ) : (
-                                <div className="text-center">
-                                    <div className="text-xl mb-5">Airdrop Tool</div>
-                                    <img
-                                        src={parachute}
-                                        style={{ width: 140 }}
-                                        className="m-auto rounded-xl mb-4"
-                                        alt="airdrop"
-                                    />
-                                    <div className="mb-5">Please connect wallet to plan a new airdrop</div>
-                                    <ConnectWallet hideNetwork={true} button={true} />
-                                    <Link to="/airdrop-history">
-                                        <div className="bg-slate-800 hover:bg-slate-700 p-2 mt-10 rounded-sm text-sm">
-                                            View airdrop history
+                                <div className="mx-auto max-w-md text-center">
+                                    <div className={`${cardBase} flex flex-col items-center`}>
+                                        <div className="mb-4 font-magic text-2xl text-white">Airdrop Tool</div>
+                                        <img
+                                            src={parachute}
+                                            style={{ width: 140 }}
+                                            className="mb-4 rounded-xl"
+                                            alt="airdrop"
+                                        />
+                                        <div className="mb-5 text-sm text-slate-400">
+                                            Connect your wallet to plan a new airdrop
                                         </div>
-                                    </Link>
+                                        <ConnectWallet hideNetwork={true} button={true} />
+                                        <Link to="/airdrop-history" className="mt-8 w-full">
+                                            <div className={`${btnSecondary} w-full`}>View airdrop history</div>
+                                        </Link>
+                                    </div>
                                 </div>
                             )}
 
-                            {error && <div className="text-red-500 mt-2">{error}</div>}
+                            {error && (
+                                <div className="mt-4 rounded-lg border border-red-500/30 bg-red-500/10 px-3 py-2 text-sm text-red-300">
+                                    {error}
+                                </div>
+                            )}
 
                             {/* Step 3 — review and confirm */}
                             {airdropDetails.length > 0 && connectedAddress && (
-                                <div className="mt-5 border p-4 rounded-lg border-slate-700">
-                                    <div className="text-base font-bold text-white">3. Review and confirm</div>
+                                <SectionCard step={3} title="Review and confirm" className="mt-5">
                                     {currentNetwork === "mainnet" && (
-                                        <div className="mt-2">
-                                            Fee: {humanReadableAmount(shroomCost)} shroom (${shroomPrice ? shroomPrice : "0"})
-                                            <br />
-                                            <a
-                                                href="https://coinhall.org/injective/inj1m35kyjuegq7ruwgx787xm53e5wfwu6n5uadurl"
-                                                className="underline text-sm"
-                                            >
-                                                buy here
-                                            </a>
+                                        <div className="flex items-center justify-between rounded-lg border border-white/10 bg-slate-950/40 px-3 py-2 text-sm">
+                                            <span className="text-slate-400">
+                                                Fee{" "}
+                                                <a
+                                                    href="https://coinhall.org/injective/inj1m35kyjuegq7ruwgx787xm53e5wfwu6n5uadurl"
+                                                    className="text-trippyYellow underline"
+                                                >
+                                                    (buy SHROOM)
+                                                </a>
+                                            </span>
+                                            <span className="font-bold text-white">
+                                                {humanReadableAmount(shroomCost)} SHROOM{" "}
+                                                <span className="font-normal text-slate-400">
+                                                    (${shroomPrice ? shroomPrice : "0"})
+                                                </span>
+                                            </span>
                                         </div>
                                     )}
                                     <button
@@ -1310,17 +1351,19 @@ const Airdrop = () => {
                                             updateDescription();
                                             setShowConfirm(true);
                                         }}
-                                        className="bg-gray-800 hover:bg-gray-700 rounded-lg p-2 w-full text-white mt-6 shadow-lg disabled:opacity-50"
+                                        className={`${btnPrimary} mt-4 w-full`}
                                     >
                                         Review airdrop details
                                     </button>
-                                </div>
+                                </SectionCard>
                             )}
 
                             {loading && (
-                                <div className="flex flex-col items-center justify-center pt-5">
+                                <div className="flex flex-col items-center justify-center pt-6">
                                     <GridLoader color="#f9d73f" />
-                                    {progress.length > 0 && <div className="mt-2">{progress}</div>}
+                                    {progress.length > 0 && (
+                                        <div className="mt-3 text-sm text-slate-400">{progress}</div>
+                                    )}
                                 </div>
                             )}
                         </div>

--- a/src/views/NftAirdrop/NftAirdropConfirmModal.tsx
+++ b/src/views/NftAirdrop/NftAirdropConfirmModal.tsx
@@ -11,6 +11,7 @@ import { performTransaction } from "../../utils/walletStrategy";
 import { isValidInjAddress } from "./csv";
 import { buildShroomFeeMessages } from "../../utils/shroomFee";
 import type { NftPair } from "./types";
+import { btnPrimary, btnGhost } from "../Airdrop/components/ui";
 
 // transfer_nft is far heavier than a cw20 transfer, so chunks stay small to
 // keep each tx under the block gas limit.
@@ -260,30 +261,42 @@ const NftAirdropConfirmModal = (props: {
 
     return (
         <>
-            <div className="justify-center items-center flex overflow-x-hidden overflow-y-auto fixed inset-0 z-50 outline-hidden focus:outline-hidden text-white text-sm">
-                <div className="relative w-auto my-4 mx-auto max-w-4xl">
-                    <div className="border-0 rounded-lg shadow-lg relative flex flex-col w-full bg-gray-800 outline-hidden focus:outline-hidden">
-                        <div className="flex items-start justify-between p-4 border-b border-solid border-blueGray-900 rounded-t">
-                            <h3 className="text-xl font-semibold">NFT Airdrop on {currentNetwork}</h3>
+            <div className="fixed inset-0 z-50 flex items-center justify-center overflow-x-hidden overflow-y-auto p-4 text-sm text-white outline-hidden focus:outline-hidden">
+                <div className="relative mx-auto my-4 w-full max-w-4xl">
+                    <div className="relative flex w-full flex-col rounded-2xl border border-white/10 bg-[#04141b] shadow-2xl shadow-black/50 outline-hidden focus:outline-hidden">
+                        <div className="flex items-center justify-between rounded-t-2xl border-b border-white/10 p-5">
+                            <h3 className="text-lg font-bold">
+                                NFT Airdrop on <span className="capitalize text-trippyYellow">{currentNetwork}</span>
+                            </h3>
+                            <button
+                                type="button"
+                                onClick={() => props.setShowModal(false)}
+                                className="text-slate-400 transition hover:text-white"
+                                aria-label="Close"
+                            >
+                                ✕
+                            </button>
                         </div>
 
-                        <div className="relative p-6 flex-auto">
-                            <p>
-                                Airdropping NFTs from <br />
-                                {props.collectionName ? `${props.collectionName} — ` : ""}
-                                {props.collectionAddress}
-                            </p>
+                        <div className="relative flex-auto p-5">
+                            <div className="rounded-lg border border-white/10 bg-slate-950/40 px-3 py-2 text-xs">
+                                <span className="text-slate-400">Airdropping NFTs from</span>
+                                <div className="mt-0.5 break-all text-slate-200">
+                                    {props.collectionName ? `${props.collectionName} — ` : ""}
+                                    <span className="font-mono">{props.collectionAddress}</span>
+                                </div>
+                            </div>
 
-                            <div className="mt-4 grid grid-cols-2 md:grid-cols-3 gap-2">
-                                <div className="rounded-md bg-slate-900 p-2">
+                            <div className="mt-4 grid grid-cols-2 gap-2 md:grid-cols-3">
+                                <div className="rounded-lg border border-white/10 bg-slate-950/40 p-2.5">
                                     <div className="text-[11px] uppercase tracking-wide text-slate-400">NFTs</div>
                                     <div className="text-sm font-bold">{sendable.length.toLocaleString()}</div>
                                 </div>
-                                <div className="rounded-md bg-slate-900 p-2">
+                                <div className="rounded-lg border border-white/10 bg-slate-950/40 p-2.5">
                                     <div className="text-[11px] uppercase tracking-wide text-slate-400">Recipients</div>
                                     <div className="text-sm font-bold">{sendable.length.toLocaleString()}</div>
                                 </div>
-                                <div className="rounded-md bg-slate-900 p-2">
+                                <div className="rounded-lg border border-white/10 bg-slate-950/40 p-2.5">
                                     <div className="text-[11px] uppercase tracking-wide text-slate-400">Transactions</div>
                                     <div className="text-sm font-bold">
                                         {txCount}
@@ -299,9 +312,9 @@ const NftAirdropConfirmModal = (props: {
                                 </div>
                             )}
 
-                            <div className="mt-5 max-h-80 overflow-y-scroll overflow-x-auto">
-                                <table className="table-auto w-full">
-                                    <thead className="text-white">
+                            <div className="mt-5 max-h-80 overflow-x-auto overflow-y-auto rounded-xl border border-white/10">
+                                <table className="w-full table-auto text-xs">
+                                    <thead className="sticky top-0 bg-[#04141b] text-slate-400">
                                         <tr>
                                             <th className="px-4 py-2 text-left">NFT</th>
                                             <th className="px-4 py-2 text-left">Recipient</th>
@@ -309,20 +322,20 @@ const NftAirdropConfirmModal = (props: {
                                     </thead>
                                     <tbody>
                                         {sendable.map((p, index) => (
-                                            <tr key={index} className="text-white border-b text-xs">
-                                                <td className="px-4 py-1 whitespace-nowrap">
+                                            <tr key={index} className="border-b border-white/5 text-white transition hover:bg-white/5">
+                                                <td className="whitespace-nowrap px-4 py-1.5">
                                                     {p.image && (
                                                         <img
                                                             src={p.image}
                                                             alt={p.tokenId}
-                                                            className="inline-block w-6 h-6 rounded mr-2 object-cover align-middle"
+                                                            className="mr-2 inline-block h-6 w-6 rounded object-cover align-middle"
                                                         />
                                                     )}
                                                     {p.name ?? `#${p.tokenId}`} (ID {p.tokenId})
                                                 </td>
-                                                <td className="px-4 py-1">
+                                                <td className="px-4 py-1.5 text-slate-300">
                                                     <a
-                                                        className="hover:text-indigo-400"
+                                                        className="transition hover:text-trippyYellow"
                                                         href={`https://explorer.injective.network/account/${p.recipient}`}
                                                     >
                                                         {p.recipient}
@@ -334,45 +347,57 @@ const NftAirdropConfirmModal = (props: {
                                 </table>
                             </div>
 
-                            {progress && <div className="mt-5">progress: {progress}</div>}
-                            {txLoading && <CircleLoader color="#36d7b7" className="mt-2 m-auto" />}
-                            {error && <div className="text-rose-600 mt-5">{error}</div>}
+                            {progress && (
+                                <div className="mt-5 text-sm text-slate-300">
+                                    <span className="text-slate-400">progress:</span> {progress}
+                                </div>
+                            )}
+                            {txLoading && <CircleLoader color="#f9d73f" className="mt-3 m-auto" />}
+                            {error && (
+                                <div className="mt-5 rounded-lg border border-rose-500/30 bg-rose-500/10 px-3 py-2 text-rose-300">
+                                    {error}
+                                </div>
+                            )}
                         </div>
 
                         {estimatedTx !== null && (
-                            <div className="mx-5 mb-2">
-                                <div>Total number of tx for airdrop: {estimatedTx}</div>
-                                <div>Completed tx: {completedTx}</div>
+                            <div className="mx-5 mb-2 flex flex-wrap gap-x-6 gap-y-1 rounded-lg border border-white/10 bg-slate-950/40 p-3">
+                                <div>Total tx: <b>{estimatedTx}</b></div>
+                                <div>Completed tx: <b>{completedTx}</b></div>
                             </div>
                         )}
-                        <div className="mx-5">
+                        <div className="mx-5 text-xs text-slate-400">
                             If the airdrop TX fails, try increasing the gas fee in your wallet. Each tx will retry up to 3
                             times.
                         </div>
                         {currentNetwork === "mainnet" && sendable.length > 0 && (
-                            <div className="m-5">
-                                Fee for airdrop: {props.shroomCost} shroom (cw20)
-                                <br />
-                                <a
-                                    href="https://coinhall.org/injective/inj1m35kyjuegq7ruwgx787xm53e5wfwu6n5uadurl"
-                                    className="underline text-sm"
-                                >
-                                    buy here
-                                </a>
-                                <div className="mt-2">Fee payed: {feePayed ? "True" : "False"}</div>
+                            <div className="mx-5 mt-3 flex items-center justify-between rounded-lg border border-white/10 bg-slate-950/40 px-3 py-2 text-sm">
+                                <span className="text-slate-400">
+                                    Fee: {props.shroomCost} SHROOM (cw20){" "}
+                                    <a
+                                        href="https://coinhall.org/injective/inj1m35kyjuegq7ruwgx787xm53e5wfwu6n5uadurl"
+                                        className="text-trippyYellow underline"
+                                    >
+                                        buy here
+                                    </a>
+                                </span>
+                                <span className={feePayed ? "font-bold text-emerald-400" : "font-bold text-slate-300"}>
+                                    {feePayed ? "Fee paid ✓" : "Fee unpaid"}
+                                </span>
                             </div>
                         )}
-                        <div className="flex items-center justify-end p-4 border-t border-solid border-blueGray-200 rounded-b">
+                        <div className="flex items-center justify-end gap-2 rounded-b-2xl border-t border-white/10 p-4">
                             <button
-                                className="text-slate-500 background-transparent font-bold uppercase px-6 py-2 text-sm outline-hidden focus:outline-hidden mr-1 mb-1 ease-linear transition-all duration-150"
+                                className={btnGhost}
                                 type="button"
                                 onClick={() => props.setShowModal(false)}
                             >
                                 Back
                             </button>
                             <button
-                                className="bg-gray-600 text-white active:bg-emerald-600 font-bold uppercase text-sm px-6 py-3 rounded-sm shadow-sm hover:shadow-lg outline-hidden focus:outline-hidden mr-1 mb-1 ease-linear transition-all duration-150"
+                                className={btnPrimary}
                                 type="button"
+                                disabled={txLoading}
                                 onClick={() => {
                                     void startAirdrop();
                                 }}
@@ -383,7 +408,7 @@ const NftAirdropConfirmModal = (props: {
                     </div>
                 </div>
             </div>
-            <div className="opacity-25 fixed inset-0 z-40 bg-black"></div>
+            <div className="fixed inset-0 z-40 bg-black/60 backdrop-blur-sm"></div>
         </>
     );
 };

--- a/src/views/NftAirdrop/components/NftGrid.tsx
+++ b/src/views/NftAirdrop/components/NftGrid.tsx
@@ -1,4 +1,5 @@
 import type { OwnedNft } from "../types";
+import { btnGhost } from "../../Airdrop/components/ui";
 
 const NftCard = ({
     nft,
@@ -16,13 +17,13 @@ const NftCard = ({
         <button
             type="button"
             onClick={() => onToggle(nft.tokenId)}
-            className={`relative rounded-lg overflow-hidden border text-left transition ${
+            className={`relative overflow-hidden rounded-xl border text-left transition ${
                 selected
                     ? "border-trippyYellow ring-2 ring-trippyYellow"
-                    : "border-slate-700 hover:border-slate-500"
+                    : "border-white/10 hover:border-white/30"
             }`}
         >
-            <div className="aspect-square bg-slate-900 flex items-center justify-center">
+            <div className="flex aspect-square items-center justify-center bg-slate-950/60">
                 {img ? (
                     <img
                         src={img}
@@ -46,11 +47,11 @@ const NftCard = ({
                     {selected ? "✓" : ""}
                 </span>
             </div>
-            <div className="p-1 bg-slate-800/90">
-                <div className="text-[11px] text-white truncate" title={nft.name ?? `#${nft.tokenId}`}>
+            <div className="bg-black/40 p-1.5">
+                <div className="truncate text-[11px] text-white" title={nft.name ?? `#${nft.tokenId}`}>
                     {nft.name ?? `#${nft.tokenId}`}
                 </div>
-                <div className="text-[10px] text-slate-400 truncate">ID: {nft.tokenId}</div>
+                <div className="truncate text-[10px] text-slate-400">ID: {nft.tokenId}</div>
             </div>
         </button>
     );
@@ -73,28 +74,20 @@ const NftGrid = ({
 }) => {
     return (
         <div>
-            <div className="flex items-center justify-between mb-2">
-                <div className="text-sm text-white">
-                    {selected.size} of {nfts.length} selected
+            <div className="mb-3 flex items-center justify-between">
+                <div className="text-sm text-slate-300">
+                    <span className="font-bold text-white">{selected.size}</span> of {nfts.length} selected
                 </div>
                 <div className="flex gap-2">
-                    <button
-                        type="button"
-                        onClick={onSelectAll}
-                        className="bg-slate-700 hover:bg-slate-600 px-3 py-1 rounded-sm text-xs"
-                    >
+                    <button type="button" onClick={onSelectAll} className={btnGhost}>
                         Select all
                     </button>
-                    <button
-                        type="button"
-                        onClick={onClear}
-                        className="bg-slate-700 hover:bg-slate-600 px-3 py-1 rounded-sm text-xs"
-                    >
+                    <button type="button" onClick={onClear} className={btnGhost}>
                         Clear
                     </button>
                 </div>
             </div>
-            <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 gap-2 max-h-112 overflow-y-auto pr-1">
+            <div className="grid max-h-112 grid-cols-3 gap-2 overflow-y-auto pr-1 sm:grid-cols-4 md:grid-cols-6">
                 {nfts.map((nft) => (
                     <NftCard
                         key={nft.tokenId}

--- a/src/views/NftAirdrop/index.tsx
+++ b/src/views/NftAirdrop/index.tsx
@@ -16,6 +16,17 @@ import { parseWalletCsv, downloadCsv } from "./csv";
 import NftGrid from "./components/NftGrid";
 import NftAirdropConfirmModal from "./NftAirdropConfirmModal";
 import type { NftPair, OwnedNft } from "./types";
+import { PiParachuteBold } from "react-icons/pi";
+import { FiShuffle, FiDownload } from "react-icons/fi";
+import SectionCard from "../Airdrop/components/SectionCard";
+import {
+    btnPrimary,
+    btnSecondary,
+    btnGhost,
+    inputBase,
+    cardBase,
+    darkSelectStyles,
+} from "../Airdrop/components/ui";
 
 const SHROOM_COST = 25000;
 const SHROOM_PAIR_ADDRESS = "inj1m35kyjuegq7ruwgx787xm53e5wfwu6n5uadurl";
@@ -192,30 +203,29 @@ const NftAirdrop = () => {
                     <div className="flex justify-center items-center min-h-full">
                         <div className="w-full max-w-(--breakpoint-lg) px-2">
                             {connectedAddress ? (
-                                <div>
-                                    <div className="text-center text-white mb-2">
-                                        <div className="text-3xl font-magic">NFT Airdrop</div>
-                                        <div className="text-sm">on Injective {currentNetwork}</div>
+                                <div className="space-y-5">
+                                    <div className="text-center text-white">
+                                        <PiParachuteBold className="mx-auto mb-2 text-trippyYellow" size={34} />
+                                        <div className="font-magic text-3xl">NFT Airdrop</div>
+                                        <div className="text-sm text-slate-400">
+                                            on Injective{" "}
+                                            <span className="capitalize text-trippyYellow">{currentNetwork}</span>
+                                        </div>
                                     </div>
-                                    <div className="flex flex-col sm:flex-row gap-2 my-4">
+                                    <div className="flex flex-col gap-2 sm:flex-row">
                                         <Link to="/airdrop" className="flex-1">
-                                            <div className="bg-slate-800 hover:bg-slate-700 p-2 rounded-sm text-center text-sm">
-                                                Airdrop a token instead →
-                                            </div>
+                                            <div className={`${btnSecondary} w-full`}>Airdrop a token instead →</div>
                                         </Link>
                                         <Link to="/airdrop-history" className="flex-1">
-                                            <div className="bg-slate-800 hover:bg-slate-700 p-2 rounded-sm text-center text-sm">
-                                                View airdrop history
-                                            </div>
+                                            <div className={`${btnSecondary} w-full`}>View airdrop history</div>
                                         </Link>
                                     </div>
 
                                     {/* Step 1 — collection */}
-                                    <div className="border p-4 rounded-lg border-slate-700">
-                                        <label className="font-bold text-base text-white mb-2 block">
-                                            1. NFT collection to airdrop
-                                        </label>
+                                    <SectionCard step={1} title="NFT collection to airdrop">
                                         <TokenSelect
+                                            dark
+                                            styles={darkSelectStyles}
                                             options={[{ label: "NFT collections", options: NFT_COLLECTIONS }]}
                                             selectedOption={collectionOption}
                                             setSelectedOption={(opt: any) => {
@@ -224,11 +234,11 @@ const NftAirdrop = () => {
                                             }}
                                         />
                                         <div className="mt-3">
-                                            <label className="text-sm text-slate-300 block mb-1">
+                                            <label className="mb-1 block text-sm text-slate-400">
                                                 or paste a CW721 collection contract address
                                             </label>
                                             <input
-                                                className="bg-white text-black w-full rounded-sm p-1 text-sm"
+                                                className={inputBase}
                                                 placeholder="inj1..."
                                                 value={customAddress}
                                                 onChange={(e) => setCustomAddress(e.target.value)}
@@ -239,26 +249,26 @@ const NftAirdrop = () => {
                                             onClick={() => {
                                                 void loadOwnedNfts();
                                             }}
-                                            className="bg-gray-800 hover:bg-gray-700 rounded-lg p-2 w-full text-white mt-4 shadow-lg disabled:opacity-50"
+                                            className={`${btnPrimary} mt-4 w-full`}
                                         >
                                             Load my NFTs
                                         </button>
                                         {collectionInfo && (
-                                            <div className="text-sm mt-4 text-white">
-                                                Collection: {collectionInfo.name}{" "}
+                                            <div className="mt-4 rounded-lg border border-white/10 bg-slate-950/40 px-3 py-2 text-sm text-white">
+                                                <span className="text-slate-400">Collection:</span> {collectionInfo.name}{" "}
                                                 {collectionInfo.symbol ? `(${collectionInfo.symbol})` : ""}
-                                                <br />
-                                                You hold {ownedNfts.length} NFT{ownedNfts.length === 1 ? "" : "s"} here
+                                                <span className="text-slate-400">
+                                                    {" "}
+                                                    · you hold {ownedNfts.length} NFT
+                                                    {ownedNfts.length === 1 ? "" : "s"} here
+                                                </span>
                                             </div>
                                         )}
-                                    </div>
+                                    </SectionCard>
 
                                     {/* Step 2 — select NFTs */}
                                     {ownedNfts.length > 0 && (
-                                        <div className="mt-5 border p-4 rounded-lg border-slate-700">
-                                            <label className="font-bold text-base text-white mb-3 block">
-                                                2. Select the NFTs to drop
-                                            </label>
+                                        <SectionCard step={2} title="Select the NFTs to drop">
                                             <NftGrid
                                                 nfts={ownedNfts}
                                                 selected={selected}
@@ -267,20 +277,16 @@ const NftAirdrop = () => {
                                                 onSelectAll={selectAll}
                                                 onClear={clearSelection}
                                             />
-                                        </div>
+                                        </SectionCard>
                                     )}
 
                                     {/* Step 3 — recipient wallets */}
                                     {ownedNfts.length > 0 && (
-                                        <div className="mt-5 border p-4 rounded-lg border-slate-700">
-                                            <label className="font-bold text-base text-white mb-2 block">
-                                                3. Upload recipient wallets (CSV)
-                                            </label>
-                                            <div className="text-sm my-2 text-slate-300">
-                                                Upload any CSV — the wallet column is detected automatically (a plain
-                                                one-address-per-line list or a multi-column export like a holder snapshot
-                                                both work). Each selected NFT is sent to one wallet, in order.
-                                            </div>
+                                        <SectionCard
+                                            step={3}
+                                            title="Upload recipient wallets (CSV)"
+                                            subtitle="The wallet column is detected automatically — a plain one-address-per-line list or a multi-column holder snapshot both work. Each selected NFT is sent to one wallet, in order."
+                                        >
                                             <div className="flex flex-wrap items-center gap-3">
                                                 <input
                                                     type="file"
@@ -288,13 +294,10 @@ const NftAirdrop = () => {
                                                     onChange={(e) => {
                                                         void handleCsvUpload(e);
                                                     }}
-                                                    className="text-white text-sm file:mr-3 file:rounded-sm file:border-0 file:bg-slate-700 file:px-3 file:py-1 file:text-white hover:file:bg-slate-600"
+                                                    className="text-sm text-slate-300 file:mr-3 file:cursor-pointer file:rounded-lg file:border file:border-white/10 file:bg-white/5 file:px-3 file:py-1.5 file:text-xs file:font-medium file:text-slate-200 hover:file:bg-white/10"
                                                 />
-                                                <button
-                                                    type="button"
-                                                    onClick={downloadTemplate}
-                                                    className="bg-slate-700 hover:bg-slate-600 px-3 py-1 rounded-sm text-xs"
-                                                >
+                                                <button type="button" onClick={downloadTemplate} className={btnGhost}>
+                                                    <FiDownload size={13} />
                                                     Download template
                                                 </button>
                                             </div>
@@ -316,38 +319,39 @@ const NftAirdrop = () => {
                                                 </div>
                                             )}
                                             {recipients.length > 0 && (
-                                                <div className="text-sm mt-2 text-white">
-                                                    {recipients.length} valid recipient
-                                                    {recipients.length === 1 ? "" : "s"} loaded
+                                                <div className="mt-3 rounded-lg border border-white/10 bg-slate-950/40 px-3 py-2 text-sm text-white">
+                                                    <span className="font-bold text-trippyYellow">
+                                                        {recipients.length}
+                                                    </span>{" "}
+                                                    valid recipient{recipients.length === 1 ? "" : "s"} loaded
                                                     {csvColumn ? (
-                                                        <span className="text-slate-400">
-                                                            {" "}
-                                                            from “{csvColumn}”
-                                                        </span>
+                                                        <span className="text-slate-400"> from “{csvColumn}”</span>
                                                     ) : null}
                                                 </div>
                                             )}
-                                        </div>
+                                        </SectionCard>
                                     )}
 
                                     {/* Step 4 — pairing preview */}
                                     {pairs.length > 0 && (
-                                        <div className="mt-5 border p-4 rounded-lg border-slate-700">
-                                            <div className="flex items-center justify-between mb-2">
-                                                <label className="font-bold text-base text-white">
-                                                    4. Assignment preview ({pairs.length} transfer
-                                                    {pairs.length === 1 ? "" : "s"})
-                                                </label>
+                                        <SectionCard
+                                            step={4}
+                                            title={`Assignment preview (${pairs.length} transfer${
+                                                pairs.length === 1 ? "" : "s"
+                                            })`}
+                                        >
+                                            <div className="mb-3 flex items-center justify-end">
                                                 <button
                                                     type="button"
                                                     onClick={shuffleRecipients}
-                                                    className="bg-slate-700 hover:bg-slate-600 px-3 py-1 rounded-sm text-xs"
+                                                    className={btnGhost}
                                                 >
+                                                    <FiShuffle size={13} />
                                                     Shuffle
                                                 </button>
                                             </div>
                                             {(leftoverNfts > 0 || leftoverWallets > 0) && (
-                                                <div className="text-amber-400 text-xs mb-2">
+                                                <div className="mb-3 space-y-1 rounded-lg border border-amber-400/30 bg-amber-400/10 px-3 py-2 text-xs text-amber-300">
                                                     {leftoverNfts > 0 && (
                                                         <div>
                                                             {leftoverNfts} selected NFT{leftoverNfts === 1 ? "" : "s"} won't
@@ -362,83 +366,103 @@ const NftAirdrop = () => {
                                                     )}
                                                 </div>
                                             )}
-                                            <div className="max-h-72 overflow-y-auto">
-                                                <table className="table-auto w-full text-xs text-white">
-                                                    <thead>
+                                            <div className="max-h-72 overflow-x-auto overflow-y-auto rounded-xl border border-white/10">
+                                                <table className="w-full table-auto text-xs text-white">
+                                                    <thead className="sticky top-0 bg-[#04141b] text-slate-400">
                                                         <tr>
-                                                            <th className="px-3 py-1 text-left">NFT</th>
-                                                            <th className="px-3 py-1 text-left">Recipient</th>
+                                                            <th className="px-3 py-2 text-left">NFT</th>
+                                                            <th className="px-3 py-2 text-left">Recipient</th>
                                                         </tr>
                                                     </thead>
                                                     <tbody>
                                                         {pairs.map((p, i) => (
-                                                            <tr key={i} className="border-b border-slate-700">
-                                                                <td className="px-3 py-1 whitespace-nowrap">
+                                                            <tr
+                                                                key={i}
+                                                                className="border-b border-white/5 transition hover:bg-white/5"
+                                                            >
+                                                                <td className="whitespace-nowrap px-3 py-1.5">
                                                                     {p.image && (
                                                                         <img
                                                                             src={p.image}
                                                                             alt={p.tokenId}
-                                                                            className="inline-block w-6 h-6 rounded mr-2 object-cover align-middle"
+                                                                            className="mr-2 inline-block h-6 w-6 rounded object-cover align-middle"
                                                                         />
                                                                     )}
                                                                     {p.name ?? `#${p.tokenId}`} (ID {p.tokenId})
                                                                 </td>
-                                                                <td className="px-3 py-1 break-all">{p.recipient}</td>
+                                                                <td className="break-all px-3 py-1.5 text-slate-300">
+                                                                    {p.recipient}
+                                                                </td>
                                                             </tr>
                                                         ))}
                                                     </tbody>
                                                 </table>
                                             </div>
+                                        </SectionCard>
+                                    )}
+
+                                    {error && (
+                                        <div className="rounded-lg border border-red-500/30 bg-red-500/10 px-3 py-2 text-sm text-red-300">
+                                            {error}
                                         </div>
                                     )}
 
-                                    {error && <div className="text-red-500 mt-2">{error}</div>}
-
                                     {/* Step 5 — review and confirm */}
                                     {pairs.length > 0 && (
-                                        <div className="mt-5 border p-4 rounded-lg border-slate-700">
-                                            <div className="text-base font-bold text-white">5. Review and confirm</div>
+                                        <SectionCard step={5} title="Review and confirm">
                                             {currentNetwork === "mainnet" && (
-                                                <div className="mt-2 text-sm">
-                                                    Fee: {humanReadableAmount(SHROOM_COST)} shroom ($
-                                                    {shroomPrice ?? "0"})
-                                                    <br />
-                                                    <a
-                                                        href="https://coinhall.org/injective/inj1m35kyjuegq7ruwgx787xm53e5wfwu6n5uadurl"
-                                                        className="underline text-sm"
-                                                    >
-                                                        buy here
-                                                    </a>
+                                                <div className="flex items-center justify-between rounded-lg border border-white/10 bg-slate-950/40 px-3 py-2 text-sm">
+                                                    <span className="text-slate-400">
+                                                        Fee{" "}
+                                                        <a
+                                                            href="https://coinhall.org/injective/inj1m35kyjuegq7ruwgx787xm53e5wfwu6n5uadurl"
+                                                            className="text-trippyYellow underline"
+                                                        >
+                                                            (buy SHROOM)
+                                                        </a>
+                                                    </span>
+                                                    <span className="font-bold text-white">
+                                                        {humanReadableAmount(SHROOM_COST)} SHROOM{" "}
+                                                        <span className="font-normal text-slate-400">
+                                                            (${shroomPrice ?? "0"})
+                                                        </span>
+                                                    </span>
                                                 </div>
                                             )}
                                             <button
                                                 disabled={loading}
                                                 onClick={() => setShowConfirm(true)}
-                                                className="bg-gray-800 hover:bg-gray-700 rounded-lg p-2 w-full text-white mt-4 shadow-lg disabled:opacity-50"
+                                                className={`${btnPrimary} mt-4 w-full`}
                                             >
                                                 Review NFT airdrop
                                             </button>
-                                        </div>
+                                        </SectionCard>
                                     )}
                                 </div>
                             ) : (
-                                <div className="text-center">
-                                    <div className="text-xl mb-5">NFT Airdrop Tool</div>
-                                    <img
-                                        src={parachute}
-                                        style={{ width: 140 }}
-                                        className="m-auto rounded-xl mb-4"
-                                        alt="airdrop"
-                                    />
-                                    <div className="mb-5">Please connect wallet to airdrop your NFTs</div>
-                                    <ConnectWallet hideNetwork={true} button={true} />
+                                <div className="mx-auto max-w-md text-center">
+                                    <div className={`${cardBase} flex flex-col items-center`}>
+                                        <div className="mb-4 font-magic text-2xl text-white">NFT Airdrop Tool</div>
+                                        <img
+                                            src={parachute}
+                                            style={{ width: 140 }}
+                                            className="mb-4 rounded-xl"
+                                            alt="airdrop"
+                                        />
+                                        <div className="mb-5 text-sm text-slate-400">
+                                            Connect your wallet to airdrop your NFTs
+                                        </div>
+                                        <ConnectWallet hideNetwork={true} button={true} />
+                                    </div>
                                 </div>
                             )}
 
                             {loading && (
-                                <div className="flex flex-col items-center justify-center pt-5">
+                                <div className="flex flex-col items-center justify-center pt-6">
                                     <GridLoader color="#f9d73f" />
-                                    {progress.length > 0 && <div className="mt-2">{progress}</div>}
+                                    {progress.length > 0 && (
+                                        <div className="mt-3 text-sm text-slate-400">{progress}</div>
+                                    )}
                                 </div>
                             )}
                         </div>


### PR DESCRIPTION
Complete design touch-up of both airdrop tools onto one shared visual system, plus a couple of functional fixes found while testing. **Logic is unchanged apart from the two fixes noted below** — everything else is className/markup and copy.

## UI restyle
- **Shared primitives** — new [`views/Airdrop/components/ui.ts`](src/views/Airdrop/components/ui.ts): three button intents (primary yellow CTA / secondary / ghost), a dark input, a card, and a dark `react-select` theme. Replaces the grab-bag of `bg-gray-800`/`bg-slate-800/700/600` and mixed `rounded-sm/md/lg` the views had accumulated.
- **Numbered `SectionCard`** shared by every step in both flows.
- Dark-themed inputs & dropdowns (were stark white-on-dark), brand-yellow CTAs, `accent-trippyYellow` checkboxes, panelled info/warn/error states, rounded dark tables with sticky headers + row hover, and restyled confirm modals (rounded card, close button, blurred backdrop).
- `TokenSelect` gains an **opt-in `dark` prop (default off)** so the other 7 views using it are visually unchanged.

## Copy
- Drop-mode **"Token holders" → "Token or liquidity (LP) token holders"**, with a helper line and a clearer LP option group, so dropping to LP holders is discoverable.

## Fixes
- **NFT load hang** — `getOwnedNFTs` could spin forever at "NFTs found: N" when a `token_uri` pointed at a slow/dead IPFS gateway (`ipfs.io` stalls never reject, and the surrounding try/catch only catches rejections). The metadata fetch now has an **8s `AbortController` timeout** and each per-token resolve is **raced against a 10s cap**, so a missing thumbnail can't block the whole load. Also hardens the token-airdrop side (shared module).
- NFT confirm **"Do NFT Airdrop"** button disables while a tx is in flight, matching the token modal.

## Verification
- `yarn typecheck` ✓ · `yarn build` ✓
- No new lint issues in any airdrop/NFT file (the 2 remaining `yarn lint` problems are pre-existing in `TokenLaunch/TokenConfirmModal.tsx` and `MyTokens/index.tsx`, untouched here).
- ⚠️ Auto-deploys on merge — QA the live flow first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)