### PR TITLE
ShroomHub venue volumes + airdrop history dedupe & TG token label

### DIFF
--- a/src/views/Airdrop/AirdropConfirmModal.tsx
+++ b/src/views/Airdrop/AirdropConfirmModal.tsx
@@ -9,6 +9,7 @@ import { useNavigate } from 'react-router-dom';
 import { CircleLoader } from "react-spinners";
 import { WALLET_LABELS } from "../../constants/walletLabels";
 import { sendTelegramMessage } from "../../modules/telegram";
+import { fetchShroomTokenMetaCached } from "../../modules/shroomTokenMeta";
 import { gql, useMutation } from '@apollo/client';
 import dayjs from "dayjs";
 import useWalletStore from "../../store/useWalletStore";
@@ -378,8 +379,18 @@ const AirdropConfirmModal = (props: {
                 ? ` [partial: ${paidRecipients.length}/${payable.length} recipients paid, ${failed.length} chunk(s) failed]`
                 : ""
 
+            // SHROOM launchpad tokens carry the raw subdenom as their on-chain
+            // symbol (e.g. "shroom_13_f9ac767…"); resolve the launch's friendly
+            // symbol so the alert reads "token dropped: SKIBI (factory/…)" rather
+            // than the opaque denom. Best-effort — falls back to the raw denom.
+            const shroomMeta = await fetchShroomTokenMetaCached(props.tokenAddress).catch(() => null)
+            const friendlySymbol = shroomMeta?.symbol ?? props.tokenSymbol
+            const tokenLabel = friendlySymbol
+                ? `${friendlySymbol} (${props.tokenAddress})`
+                : props.tokenAddress
+
             if (currentNetwork == "mainnet") await sendTelegramMessage(
-                `wallet ${connectedAddress} performed an airdrop on trippyinj!${partialNote}\ntoken dropped: ${props.tokenAddress}\n` +
+                `wallet ${connectedAddress} performed an airdrop on trippyinj!${partialNote}\ntoken dropped: ${tokenLabel}\n` +
                 `num participants: ${paidRecipients.length}\n` +
                 `${props.criteria}\n${props.description}`
             )
@@ -445,7 +456,7 @@ const AirdropConfirmModal = (props: {
             if (checkpointKey) clearCheckpoint(checkpointKey)
             void navigate('/airdrop-history');
         }
-    }, [props.airdropDetails, props.shroomCost, props.tokenAddress, props.tokenDecimals, feePayed, currentNetwork, sendAirdrops, connectedAddress, navigate, payFee, insertAirdropLog, props.criteria, props.description, insertWallets, insertTokenDropped, payable, totalOut, checkpointKey])
+    }, [props.airdropDetails, props.shroomCost, props.tokenAddress, props.tokenDecimals, props.tokenSymbol, feePayed, currentNetwork, sendAirdrops, connectedAddress, navigate, payFee, insertAirdropLog, props.criteria, props.description, insertWallets, insertTokenDropped, payable, totalOut, checkpointKey])
 
     // Reconciliation receipt: every intended recipient with its amount and
     // whether it's been paid yet — handy after a partial run.

--- a/src/views/AirdropHistory/index.tsx
+++ b/src/views/AirdropHistory/index.tsx
@@ -9,6 +9,81 @@ import useNetworkStore from "../../store/useNetworkStore";
 import AirdropCard from "../../components/App/AIrdropCord";
 
 
+// A partial airdrop that's later resumed/retried is written as a SECOND log row
+// (the resume re-broadcasts nothing already paid but re-logs the FULL tx set —
+// see AirdropConfirmModal), so the retry and the partial share on-chain tx
+// hashes. Collapse any logs connected by a shared tx hash into one entry,
+// keeping the most-complete run, so the same airdrop isn't shown — or counted —
+// twice.
+const parseHashes = (s?: string): string[] =>
+    (s ?? "").split(",").map((h) => h.trim()).filter(Boolean)
+
+const isPartialLog = (log: any): boolean => /\[partial:/i.test(log?.description ?? "")
+
+const timeOf = (log: any): number => {
+    const t = new Date(log?.time).getTime()
+    return Number.isFinite(t) ? t : 0
+}
+
+// The representative of a group: the finished run. Prefer most recipients, then
+// most txs, then the non-partial row, then the newest.
+const preferred = (a: any, b: any): any => {
+    const pa = Number(a.total_participants) || 0
+    const pb = Number(b.total_participants) || 0
+    if (pa !== pb) return pa > pb ? a : b
+    const ha = parseHashes(a.tx_hashes).length
+    const hb = parseHashes(b.tx_hashes).length
+    if (ha !== hb) return ha > hb ? a : b
+    const partA = isPartialLog(a)
+    const partB = isPartialLog(b)
+    if (partA !== partB) return partA ? b : a
+    return timeOf(a) >= timeOf(b) ? a : b
+}
+
+const dedupeAirdropLogs = (logs: any[]): any[] => {
+    // Union-find over logs linked by a shared tx hash.
+    const parent = logs.map((_, i) => i)
+    const find = (i: number): number => {
+        while (parent[i] !== i) {
+            parent[i] = parent[parent[i]]
+            i = parent[i]
+        }
+        return i
+    }
+    const union = (i: number, j: number) => {
+        parent[find(i)] = find(j)
+    }
+
+    const seen = new Map<string, number>() // tx hash -> first log index carrying it
+    logs.forEach((log, i) => {
+        for (const h of parseHashes(log.tx_hashes)) {
+            const prev = seen.get(h)
+            if (prev != null) union(prev, i)
+            else seen.set(h, i)
+        }
+    })
+
+    // Reduce each group to its best representative.
+    const rep = new Map<number, any>()
+    logs.forEach((log, i) => {
+        const r = find(i)
+        const cur = rep.get(r)
+        rep.set(r, cur ? preferred(cur, log) : log)
+    })
+
+    // Emit one row per group, preserving the incoming (time desc) order — the
+    // group surfaces at the position of its newest member.
+    const emitted = new Set<number>()
+    const out: any[] = []
+    logs.forEach((_, i) => {
+        const r = find(i)
+        if (emitted.has(r)) return
+        emitted.add(r)
+        out.push(rep.get(r))
+    })
+    return out
+}
+
 const AIRDROP_HISTORY_QUERY = gql`
 query getAirdropHistory {
   airdrop_tracker_airdroplog(order_by: {time: desc}) {
@@ -45,7 +120,7 @@ const AirdropHistory = () => {
 
     useEffect(() => {
         if (!data) return
-        setAirdropData(data.airdrop_tracker_airdroplog)
+        setAirdropData(dedupeAirdropLogs(data.airdrop_tracker_airdroplog))
     }, [data])
 
     const totalWallets = airdropData.reduce(

--- a/src/views/ShroomHub/ecosystem.ts
+++ b/src/views/ShroomHub/ecosystem.ts
@@ -19,6 +19,11 @@ export const DOJO_SHROOM_INJ = 'inj1m35kyjuegq7ruwgx787xm53e5wfwu6n5uadurl';
 export const CHOICE_SHROOM_INJ = 'inj1uyjjnykz0slq0w4n6k2xgleykqk9k5qkfctmw5';
 export const MITO_VAULT = 'inj1g89dl74lyre9q6rjua9l37pcc7psnw66capurp';
 
+// The Helix SHROOM/INJ orderbook (market id 97) that the Mito vault makes.
+// Its trading volume is what we show on the on-chain "Mito" liquidity row.
+export const SHROOM_INJ_ORDERBOOK_REF =
+    '0xc6b6d6627aeed8b9c29810163bed47d25c695d51a2aa8599fc5e39b2d88ef934';
+
 export const CHOICE_TICKERS_URL =
     'https://api.choice.exchange/api/coingecko/tickers';
 
@@ -306,6 +311,55 @@ export const fetchChoicePoolMeta = async (
             if (r?.pool_id && Number.isFinite(v)) tvl[r.pool_id] = v;
         }
         return { symbols, tvl };
+    } catch {
+        return empty;
+    }
+};
+
+// ---- 24h volume for the on-chain venues (Choice indexer) -----------------
+//
+// The DojoSwap AMM pool and the Helix SHROOM/INJ orderbook (market-made by the
+// Mito vault) are read on-chain for TVL, but the CoinGecko tickers feed only
+// carries Choice's own pools — so those rows have no 24h volume. Choice's
+// indexer DOES track their trades, so pull their volume from
+// `analytics_spotmarket` (keyed by ref_id: the pool address / the market hash).
+export interface OnchainVolumes {
+    dojoShroomInj: number | null; // DojoSwap SHROOM/INJ pool 24h vol
+    shroomInjOrderbook: number | null; // Helix orderbook (Mito) 24h vol
+}
+
+const ONCHAIN_VOL_QUERY = `
+    query ShroomOnchainVolumes($refs: [String!]) {
+        analytics_spotmarket(where: { ref_id: { _in: $refs } }) {
+            ref_id
+            volume24h_usd
+        }
+    }`;
+
+// Best-effort: any failure yields nulls, so the rows just render "—" as before.
+export const fetchOnchainVolumes = async (): Promise<OnchainVolumes> => {
+    const empty: OnchainVolumes = { dojoShroomInj: null, shroomInjOrderbook: null };
+    if (!CHOICE_GRAPHQL_URL) return empty;
+    try {
+        const res = await fetch(CHOICE_GRAPHQL_URL, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                query: ONCHAIN_VOL_QUERY,
+                variables: { refs: [DOJO_SHROOM_INJ, SHROOM_INJ_ORDERBOOK_REF] },
+            }),
+        });
+        if (!res.ok) return empty;
+        const json = await res.json();
+        const byRef: Record<string, number> = {};
+        for (const r of json?.data?.analytics_spotmarket ?? []) {
+            const v = Number(r?.volume24h_usd);
+            if (r?.ref_id && Number.isFinite(v)) byRef[r.ref_id] = v;
+        }
+        return {
+            dojoShroomInj: byRef[DOJO_SHROOM_INJ] ?? null,
+            shroomInjOrderbook: byRef[SHROOM_INJ_ORDERBOOK_REF] ?? null,
+        };
     } catch {
         return empty;
     }

--- a/src/views/ShroomHub/index.tsx
+++ b/src/views/ShroomHub/index.tsx
@@ -32,6 +32,7 @@ import {
     DOJO_SHROOM_INJ,
     ECOSYSTEM_HOLDERS_QUERY,
     fetchChoicePools,
+    fetchOnchainVolumes,
     type HolderInfo,
     MITO_VAULT,
     parseHolderInfo,
@@ -380,10 +381,16 @@ const ShroomHub = () => {
         setPoolsLoading(true);
         const module = new TokenUtils(networkConfig);
         try {
-            const [injPrice, mitoVault, dojoAmounts] = await Promise.all([
+            const [injPrice, mitoVault, dojoAmounts, onchainVol] = await Promise.all([
                 module.getINJPrice(),
                 module.fetchMitoVault(MITO_VAULT).catch(() => null),
                 module.getPoolAmounts(DOJO_SHROOM_INJ).catch(() => null),
+                // 24h volume for these venues lives in the Choice indexer, not
+                // the tickers feed — the Mito row shows the Helix orderbook vol.
+                fetchOnchainVolumes().catch(() => ({
+                    dojoShroomInj: null,
+                    shroomInjOrderbook: null,
+                })),
             ]);
             const inj = Number(injPrice) || 0;
 
@@ -398,7 +405,7 @@ const ShroomHub = () => {
                     base: 'SHROOM',
                     quote: 'INJ',
                     tvlUsd: mitoTvl,
-                    vol24hUsd: null,
+                    vol24hUsd: onchainVol.shroomInjOrderbook,
                 });
             }
             const dojoTvl = injReserve(dojoAmounts) * inj * 2;
@@ -410,7 +417,7 @@ const ShroomHub = () => {
                     base: 'SHROOM',
                     quote: 'INJ',
                     tvlUsd: dojoTvl,
-                    vol24hUsd: null,
+                    vol24hUsd: onchainVol.dojoShroomInj,
                 });
             }
 


### PR DESCRIPTION
Three small SHROOM-ecosystem FE fixes (all frontend-only, no backend/migration).

## 1. ShroomHub — 24h volume for on-chain Mito & DojoSwap rows
The **SHROOM/INJ Mito** and **SHROOM/INJ DojoSwap** liquidity rows are read on-chain (the CoinGecko tickers feed only covers Choice's own pools), so both had `vol24hUsd` hardcoded to `null` and rendered `—` — even though Choice's own UI shows volume for them.

Choice's indexer **does** track their trades. New `fetchOnchainVolumes()` pulls the DojoSwap pool + Helix SHROOM/INJ orderbook (the market the Mito vault makes) 24h volumes from `analytics_spotmarket` and attaches them to those rows. Verified live: DojoSwap ≈ $1,064, orderbook/Mito ≈ $1,220. Bonus: the hero and SHROOM-card 24h totals now include these venues.

## 2. Airdrop History — dedupe retried airdrops
A partial airdrop that's later resumed is written as a **second** log row, and the resume re-logs the full tx set — so the partial and the completed run share on-chain tx hashes. `dedupeAirdropLogs` collapses logs linked by a shared tx hash into one entry (keeping the most-complete run: most recipients → most txs → non-partial → newest), so a retried airdrop isn't shown *or counted in the header totals* twice.

Verified against live data: rows `97` (14,156) + `96` (13,656, partial) collapse to `97`; all other distinct drops stay separate and in order. Uses tx-hash overlap (ground truth), so genuinely separate airdrops are never merged.

## 3. Telegram alert — friendly shroom-pad token label
The alert put the raw `tokenAddress` in `token dropped:` — and the trippinj token index stores the raw subdenom as the symbol (`SHROOM_13_F9AC767…`). Now resolves the launch's real symbol via the same `LaunchpadCore` metadata reader the history card uses, so alerts read `token dropped: SKIBI (factory/…)`. Best-effort; falls back to the raw denom for non-launchpad tokens.

## Testing
- `eslint --max-warnings 0` clean on all four files; `npm run build` green.
- Dedup logic replayed against the live `airdrop_tracker_airdroplog` rows (only the one duplicate collapsed).

⚠️ Auto-deploys live on merge — QA on a dev build first (`/shroom-hub` volume column, `/airdrop-history` single SKIBI card + header count).

🤖 Generated with [Claude Code](https://claude.com/claude-code)