### PR TITLE
ShroomHub: fix intermittent missing 24h volume (source from indexer)

### DIFF
--- a/src/views/ShroomHub/ecosystem.ts
+++ b/src/views/ShroomHub/ecosystem.ts
@@ -316,62 +316,66 @@ export const fetchChoicePoolMeta = async (
     }
 };
 
-// ---- 24h volume for the on-chain venues (Choice indexer) -----------------
+// ---- 24h volume for every venue (Choice indexer) -------------------------
 //
-// The DojoSwap AMM pool and the Helix SHROOM/INJ orderbook (market-made by the
-// Mito vault) are read on-chain for TVL, but the CoinGecko tickers feed only
-// carries Choice's own pools — so those rows have no 24h volume. Choice's
-// indexer DOES track their trades, so pull their volume from
-// `analytics_spotmarket` (keyed by ref_id: the pool address / the market hash).
-export interface OnchainVolumes {
-    dojoShroomInj: number | null; // DojoSwap SHROOM/INJ pool 24h vol
-    shroomInjOrderbook: number | null; // Helix orderbook (Mito) 24h vol
-}
-
-const ONCHAIN_VOL_QUERY = `
-    query ShroomOnchainVolumes($refs: [String!]) {
-        analytics_spotmarket(where: { ref_id: { _in: $refs } }) {
+// `analytics_spotmarket` carries an authoritative, pre-computed USD 24h volume
+// for EVERY SHROOM/SAI market — Choice AMM/CLMM, DojoSwap, and the Helix
+// orderbook the Mito vault makes — keyed by `ref_id`: the pool contract address
+// for AMM/CLMM (which equals the tickers feed's `pool_id`) or the market hash
+// for the orderbook.
+//
+// We key volume off this rather than deriving `base_volume × a client-side USD
+// price`, because that price map isn't populated until the async token-stats
+// query resolves — so on an early render (SHROOM/SAI price still 0) every pool
+// without an INJ/USDC leg (SHROOM/SAI, SAI/BERB, SAI/ERIC, …) rendered no
+// volume. The indexer figure is always in USD and needs no client price.
+const MARKET_VOL_QUERY = `
+    query ShroomMarketVolumes {
+        analytics_spotmarket(
+            where: {
+                _or: [
+                    { base_asset: { symbol: { _in: ["SHROOM", "SAI"] } } }
+                    { quote_asset: { symbol: { _in: ["SHROOM", "SAI"] } } }
+                ]
+            }
+        ) {
             ref_id
             volume24h_usd
         }
     }`;
 
-// Best-effort: any failure yields nulls, so the rows just render "—" as before.
-export const fetchOnchainVolumes = async (): Promise<OnchainVolumes> => {
-    const empty: OnchainVolumes = { dojoShroomInj: null, shroomInjOrderbook: null };
-    if (!CHOICE_GRAPHQL_URL) return empty;
+// ref_id (pool address / market hash) -> 24h USD volume. Empty on any failure,
+// so callers fall back to the price-map estimate.
+export const fetchMarketVolumes = async (): Promise<Record<string, number>> => {
+    if (!CHOICE_GRAPHQL_URL) return {};
     try {
         const res = await fetch(CHOICE_GRAPHQL_URL, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-                query: ONCHAIN_VOL_QUERY,
-                variables: { refs: [DOJO_SHROOM_INJ, SHROOM_INJ_ORDERBOOK_REF] },
-            }),
+            body: JSON.stringify({ query: MARKET_VOL_QUERY }),
         });
-        if (!res.ok) return empty;
+        if (!res.ok) return {};
         const json = await res.json();
-        const byRef: Record<string, number> = {};
+        const out: Record<string, number> = {};
         for (const r of json?.data?.analytics_spotmarket ?? []) {
             const v = Number(r?.volume24h_usd);
-            if (r?.ref_id && Number.isFinite(v)) byRef[r.ref_id] = v;
+            if (r?.ref_id && Number.isFinite(v)) out[r.ref_id] = v;
         }
-        return {
-            dojoShroomInj: byRef[DOJO_SHROOM_INJ] ?? null,
-            shroomInjOrderbook: byRef[SHROOM_INJ_ORDERBOOK_REF] ?? null,
-        };
+        return out;
     } catch {
-        return empty;
+        return {};
     }
 };
 
-// Keep only the SHROOM/SAI Choice pools. 24h USD volume = the token-unit
-// `base_volume`/`target_volume` priced off whichever leg we know a USD price for
-// (SHROOM / SAI / INJ) — every SHROOM/SAI pool has at least one such leg.
+// Keep only the SHROOM/SAI Choice pools. 24h USD volume comes from the indexer
+// (`marketVol`, keyed by pool_id == analytics_spotmarket.ref_id); we fall back
+// to `base_volume`/`target_volume` priced off a known leg (SHROOM / SAI / INJ)
+// only when the pool isn't indexed.
 export const parseChoiceTickers = (
     results: RawTicker[],
     priceUsd: Record<string, number>,
     meta: ChoicePoolMeta = { symbols: {}, tvl: {} },
+    marketVol: Record<string, number> = {},
 ): PoolLiq[] => {
     const resolve = (currency: string): string =>
         meta.symbols[currency] ?? symbolOf(currency);
@@ -382,11 +386,15 @@ export const parseChoiceTickers = (
         const touches = (s: string) => s === 'SHROOM' || s === 'SAI';
         if (!touches(baseSym) && !touches(quoteSym)) continue;
 
-        const bp = priceUsd[baseSym];
-        const qp = priceUsd[quoteSym];
-        let vol: number | null = null;
-        if (bp) vol = Number(t.base_volume) * bp;
-        else if (qp) vol = Number(t.target_volume) * qp;
+        // Prefer the indexer's authoritative USD volume; only estimate from the
+        // tickers token-unit volumes if this pool_id isn't in the market feed.
+        let vol: number | null = marketVol[t.pool_id] ?? null;
+        if (vol == null) {
+            const bp = priceUsd[baseSym];
+            const qp = priceUsd[quoteSym];
+            if (bp) vol = Number(t.base_volume) * bp;
+            else if (qp) vol = Number(t.target_volume) * qp;
+        }
 
         // Prefer the indexer's CLMM snapshot TVL: the coingecko adapter can't
         // price a concentrated-liquidity launchpad pool and returns a negative
@@ -414,6 +422,7 @@ export const parseChoiceTickers = (
 // pools fit one page); tolerate a bare array too in case that changes.
 export const fetchChoicePools = async (
     priceUsd: Record<string, number>,
+    marketVol: Record<string, number> = {},
 ): Promise<PoolLiq[]> => {
     const res = await fetch(CHOICE_TICKERS_URL);
     if (!res.ok) throw new Error(`choice tickers ${res.status}`);
@@ -435,7 +444,7 @@ export const fetchChoicePools = async (
         if (q.includes('…')) unresolved.add(t.target_currency);
     }
     const meta = await fetchChoicePoolMeta([...unresolved], [...poolIds]);
-    return parseChoiceTickers(results, priceUsd, meta);
+    return parseChoiceTickers(results, priceUsd, meta, marketVol);
 };
 
 // ---- aggregations for the three breakdown views -------------------------

--- a/src/views/ShroomHub/index.tsx
+++ b/src/views/ShroomHub/index.tsx
@@ -32,9 +32,10 @@ import {
     DOJO_SHROOM_INJ,
     ECOSYSTEM_HOLDERS_QUERY,
     fetchChoicePools,
-    fetchOnchainVolumes,
+    fetchMarketVolumes,
     type HolderInfo,
     MITO_VAULT,
+    SHROOM_INJ_ORDERBOOK_REF,
     parseHolderInfo,
     parseTokenStats,
     type PoolLiq,
@@ -381,20 +382,19 @@ const ShroomHub = () => {
         setPoolsLoading(true);
         const module = new TokenUtils(networkConfig);
         try {
-            const [injPrice, mitoVault, dojoAmounts, onchainVol] = await Promise.all([
+            const [injPrice, mitoVault, dojoAmounts, marketVol] = await Promise.all([
                 module.getINJPrice(),
                 module.fetchMitoVault(MITO_VAULT).catch(() => null),
                 module.getPoolAmounts(DOJO_SHROOM_INJ).catch(() => null),
-                // 24h volume for these venues lives in the Choice indexer, not
-                // the tickers feed — the Mito row shows the Helix orderbook vol.
-                fetchOnchainVolumes().catch(() => ({
-                    dojoShroomInj: null,
-                    shroomInjOrderbook: null,
-                })),
+                // Authoritative per-market 24h USD volume from the Choice indexer
+                // (keyed by ref_id), used for every venue below. Never rejects —
+                // yields an empty map on failure.
+                fetchMarketVolumes(),
             ]);
             const inj = Number(injPrice) || 0;
 
-            // Non-Choice venues, read on-chain.
+            // Non-Choice venues, read on-chain; volume keyed off the indexer feed
+            // (the Mito row shows the Helix SHROOM/INJ orderbook volume).
             const onchain: PoolLiq[] = [];
             const mitoTvl = Number(mitoVault?.currentTvl) || 0;
             if (mitoTvl > 0) {
@@ -405,7 +405,7 @@ const ShroomHub = () => {
                     base: 'SHROOM',
                     quote: 'INJ',
                     tvlUsd: mitoTvl,
-                    vol24hUsd: onchainVol.shroomInjOrderbook,
+                    vol24hUsd: marketVol[SHROOM_INJ_ORDERBOOK_REF] ?? null,
                 });
             }
             const dojoTvl = injReserve(dojoAmounts) * inj * 2;
@@ -417,7 +417,7 @@ const ShroomHub = () => {
                     base: 'SHROOM',
                     quote: 'INJ',
                     tvlUsd: dojoTvl,
-                    vol24hUsd: onchainVol.dojoShroomInj,
+                    vol24hUsd: marketVol[DOJO_SHROOM_INJ] ?? null,
                 });
             }
 
@@ -425,12 +425,15 @@ const ShroomHub = () => {
             // Choice pool if the feed is unreachable.
             let choicePools: PoolLiq[] = [];
             try {
-                choicePools = await fetchChoicePools({
-                    INJ: inj,
-                    SHROOM: shroomPrice,
-                    SAI: saiPrice,
-                    USDC: 1,
-                });
+                choicePools = await fetchChoicePools(
+                    {
+                        INJ: inj,
+                        SHROOM: shroomPrice,
+                        SAI: saiPrice,
+                        USDC: 1,
+                    },
+                    marketVol,
+                );
             } catch (e) {
                 console.error('choice tickers failed', e);
             }


### PR DESCRIPTION
Follow-up to #168 (which landed before this commit could be added to it).

## Problem
On ShroomHub "Liquidity sources", 24h volume **sometimes** didn't load — specifically for pools with no INJ/USDC leg: **SHROOM/SAI, SAI/BERB, SAI/ERIC, SAI/MOON**.

Choice-pool volume was computed client-side as `base_volume × priceUsd[leg]`, but `priceUsd` only gains SHROOM/SAI prices once the async token-stats query resolves. On an early render those prices are 0, so any pool whose only priced leg is SHROOM or SAI fell back to `null` → `—`. Pools with an INJ or USDC leg happened to work, which is why it looked intermittent/partial.

## Fix
Take the authoritative pre-computed `volume24h_usd` straight from Choice's `analytics_spotmarket`, keyed by `ref_id` (== the tickers feed's `pool_id` for AMM/CLMM, the market hash for the orderbook). One query now feeds **every** venue — the Choice pools *and* the on-chain Mito/DojoSwap rows (replacing the narrower `fetchOnchainVolumes` from #168). No client-side price math → no race. The `base_volume × price` path remains only as a fallback for any pool the indexer doesn't return.

Verified live by replaying the race state (SHROOM/SAI price = 0): the previously-`—` pools now show correct USD volume (SAI/SHROOM ≈ $3.4k, SAI/BERB ≈ $3.5k, SAI/ERIC ≈ $672, SAI/MOON ≈ $19, SHROOM/USDC ≈ $40) on first paint. Dead pools (HPNJ/QUNT) now show a known `$0` instead of `—`.

`eslint --max-warnings 0` clean; `npm run build` green.

⚠️ Auto-deploys live on merge — QA `/shroom-hub` on a dev build (volume column should be populated on first paint, before token prices load).

🤖 Generated with [Claude Code](https://claude.com/claude-code)