### PR TITLE
Airdrop: fix chunks bricked by bank-blocked recipients + resize by measured gas

### DIFF
--- a/src/views/Airdrop/AirdropConfirmModal.tsx
+++ b/src/views/Airdrop/AirdropConfirmModal.tsx
@@ -15,8 +15,9 @@ import dayjs from "dayjs";
 import useWalletStore from "../../store/useWalletStore";
 import useNetworkStore from "../../store/useNetworkStore";
 import { performTransaction } from "../../utils/walletStrategy";
-import { CHUNK_SIZE } from "./distribution";
+import { chunkSizeForDenom, isNativeDenomSend } from "./distribution";
 import { isValidInjAddress } from "./csv";
+import { isBlockedRecipient } from "./blockedAddresses";
 import { humanReadableAmount } from "./format";
 import { downloadCsv } from "../../utils/csv";
 import {
@@ -113,20 +114,40 @@ const AirdropConfirmModal = (props: {
 
     // Resume/idempotency state, seeded from the persisted checkpoint (if any).
     const [paidCount, setPaidCount] = useState(0)
-    const [failedChunks, setFailedChunks] = useState<number[]>([])
+    // Individual recipients the chain refused after retries + bisection (a
+    // blocked module account, an EVM precompile, …). These are the *only*
+    // addresses a failed run leaves unpaid — never their chunk-mates.
+    const [failedRecipients, setFailedRecipients] = useState<string[]>([])
 
     const [insertAirdropLog] = useMutation(INSERT_AIRDROP_MUTATION)
     const [insertWallets] = useMutation(INSERT_WALLETS_MUTATION)
     const [insertTokenDropped] = useMutation(INSERT_TOKEN_MUTATION)
 
-    // A recipient is actually paid only if it's included AND rounds to a
-    // non-zero amount at the token's decimals. (CSV excludes keep their amount,
-    // so checking includeInDrop here matters — not just amount > 0.)
+    // A recipient is actually paid only if it's included, rounds to a non-zero
+    // amount at the token's decimals, AND isn't a bank-blocked address. (CSV
+    // excludes keep their amount, so checking includeInDrop here matters — not
+    // just amount > 0.) Blocked module accounts (e.g. the exchange module, which
+    // holds every Helix depositor's balance) otherwise slip in as "holders" and
+    // revert their whole multisend chunk at simulation.
     const isPayable = useCallback(
         (record: any) =>
             record.includeInDrop &&
-            Number(Number(record.amountToAirdrop).toFixed(props.tokenDecimals)) > 0,
+            Number(Number(record.amountToAirdrop).toFixed(props.tokenDecimals)) > 0 &&
+            !isBlockedRecipient(record.address),
         [props.tokenDecimals],
+    );
+
+    // How many otherwise-payable recipients were dropped purely for being a
+    // bank-blocked address — surfaced in the pre-flight so it's not a surprise.
+    const blockedCount = useMemo(
+        () =>
+            (props.airdropDetails || []).filter(
+                (r: any) =>
+                    r.includeInDrop &&
+                    Number(Number(r.amountToAirdrop).toFixed(props.tokenDecimals)) > 0 &&
+                    isBlockedRecipient(r.address),
+            ).length,
+        [props.airdropDetails, props.tokenDecimals],
     );
 
     const payable = useMemo(
@@ -141,7 +162,7 @@ const AirdropConfirmModal = (props: {
         () => payable.filter((r: any) => !isValidInjAddress(r.address)).length,
         [payable],
     );
-    const txCount = Math.ceil(payable.length / CHUNK_SIZE);
+    const txCount = Math.ceil(payable.length / chunkSizeForDenom(props.tokenAddress));
 
     // The exact `{address, amount}` rows that will be sent — the single source of
     // truth for both the send loop and the checkpoint key, so the key always
@@ -198,14 +219,9 @@ const AirdropConfirmModal = (props: {
         const key = checkpointKey;
         const base = { sender: injectiveAddress, token: props.tokenAddress, total: records.length };
 
-        const isNative = (
-            denom.includes("factory") ||
-            denom.includes("peggy") ||
-            denom.includes("ibc") ||
-            denom == "inj"
-        )
+        const isNative = isNativeDenomSend(denom)
 
-        const chunkSize = CHUNK_SIZE;
+        const chunkSize = chunkSizeForDenom(denom);
         const chunks: { address: string; amount: string }[][] = [];
 
         for (let i = 0; i < records.length; i += chunkSize) {
@@ -223,103 +239,102 @@ const AirdropConfirmModal = (props: {
         setCompletedTx(transactions.length)
         setPaidCount(successfullyProcessed.size)
 
-        // Chunks that couldn't be sent after their retries. We record them and
-        // keep going instead of aborting the whole run, so one bad chunk no
-        // longer strands the other 35.
-        const failed: number[] = [];
+        // Individual recipients the chain refused even when sent alone — these
+        // are the only addresses left unpaid. The last error seen is kept so the
+        // UI can show *why* (a blocked account, a precompile, a real revert).
+        const failedAddrs: string[] = [];
+        let lastError: unknown = null;
 
-        for (let ci = 0; ci < chunks.length; ci++) {
-            const filteredChunk = chunks[ci].filter(record => !successfullyProcessed.has(record.address));
+        type Row = { address: string; amount: string };
 
-            if (filteredChunk.length === 0) {
-                continue; // every recipient in this chunk was already paid
+        // Build the send message for an arbitrary group of recipients: one CW20
+        // transfer per recipient for cw20 tokens, or a single balanced
+        // MsgMultiSend for native/factory/peggy/ibc denoms.
+        const buildMsgs = (group: Row[]) => {
+            if (!isNative) {
+                return group.map((record) =>
+                    MsgExecuteContractCompat.fromJSON({
+                        contractAddress: denom,
+                        sender: injectiveAddress,
+                        msg: {
+                            transfer: {
+                                recipient: record.address,
+                                amount: new BigNumberInBase(record.amount).toWei(decimals).toFixed(),
+                            },
+                        },
+                    }),
+                );
             }
+            const totalToSend = group.reduce(
+                (acc, record) => acc.plus(new BigNumberInBase(record.amount).toWei(decimals)),
+                new BigNumberInWei(0),
+            );
+            return MsgMultiSend.fromJSON({
+                inputs: [{ address: injectiveAddress, coins: [{ denom, amount: totalToSend.toFixed() }] }],
+                outputs: group.map((record) => ({
+                    address: record.address,
+                    coins: [{ amount: new BigNumberInBase(record.amount).toWei(decimals).toFixed(), denom }],
+                })),
+            });
+        };
 
+        // Broadcast one group, retrying transient failures. Returns true on a
+        // landed tx (progress is persisted before anything else can throw).
+        const sendGroup = async (group: Row[]): Promise<boolean> => {
             let retries = 3;
-            let success = false;
-
-            while (retries > 0 && !success) {
+            while (retries > 0) {
                 try {
-                    let msg;
-                    if (!isNative) {
-                        msg = filteredChunk.map((record) => {
-                            return MsgExecuteContractCompat.fromJSON({
-                                contractAddress: denom,
-                                sender: injectiveAddress,
-                                msg: {
-                                    transfer: {
-                                        recipient: record.address,
-                                        amount: new BigNumberInBase(record.amount)
-                                            .toWei(decimals)
-                                            .toFixed()
-                                    },
-                                },
-                            });
-                        });
-                    } else {
-                        const totalChunkToSend = filteredChunk.reduce((acc, record) => {
-                            return acc.plus(new BigNumberInBase(record.amount).toWei(decimals));
-                        }, new BigNumberInWei(0));
-
-                        msg = MsgMultiSend.fromJSON({
-                            inputs: [
-                                {
-                                    address: injectiveAddress,
-                                    coins: [
-                                        {
-                                            denom,
-                                            amount: totalChunkToSend.toFixed(),
-                                        },
-                                    ],
-                                },
-                            ],
-                            outputs: filteredChunk.map((record: { address: any; amount: BigNumber.Value; }) => {
-                                return {
-                                    address: record.address,
-                                    coins: [
-                                        {
-                                            amount: new BigNumberInBase(record.amount)
-                                                .toWei(decimals)
-                                                .toFixed(),
-                                            denom,
-                                        },
-                                    ],
-                                };
-                            }),
-                        });
-                    }
-
-                    const response = await performTransaction(injectiveAddress, msg as any, {
+                    const response = await performTransaction(injectiveAddress, buildMsgs(group) as any, {
                         gasBufferCoefficient: AIRDROP_GAS_BUFFER,
                     });
-
-                    // Persist progress BEFORE anything else can throw, so a crash
-                    // right after broadcast can't lose a landed tx.
-                    filteredChunk.forEach(record => successfullyProcessed.add(record.address));
-                    transactions.push(response!.txHash)
+                    group.forEach((record) => successfullyProcessed.add(record.address));
+                    transactions.push(response!.txHash);
                     if (key) {
-                        recordChunkPaid(key, base, filteredChunk.map(r => r.address), response!.txHash);
+                        recordChunkPaid(key, base, group.map((r) => r.address), response!.txHash);
                     }
-                    setCompletedTx(transactions.length)
-                    setPaidCount(successfullyProcessed.size)
-                    success = true;
+                    setCompletedTx(transactions.length);
+                    setPaidCount(successfullyProcessed.size);
+                    return true;
                 } catch (error) {
-                    console.error(`Chunk ${ci + 1}/${chunks.length} failed, retrying...`, error);
+                    lastError = error;
+                    console.error(`Send of ${group.length} recipient(s) failed, retrying...`, error);
                     retries -= 1;
                     if (retries > 0) {
                         await sleep(1000 * (3 - retries)); // 1s, then 2s backoff
                     }
                 }
             }
+            return false;
+        };
 
-            if (!success) {
-                console.error(`Chunk ${ci + 1}/${chunks.length} failed after retries — continuing`);
-                failed.push(ci);
+        // Send a group; if it fails, *bisect* it so a single unsendable recipient
+        // (a blocked account, precompile, …) only ever strands itself instead of
+        // its ~499 chunk-mates. Recurses down to a single address, which — if it
+        // still fails alone — is recorded and skipped.
+        const processGroup = async (group: Row[]): Promise<void> => {
+            const pending = group.filter((record) => !successfullyProcessed.has(record.address));
+            if (pending.length === 0) return; // already paid on a previous attempt
+
+            if (await sendGroup(pending)) return;
+
+            if (pending.length === 1) {
+                console.error(`Recipient ${pending[0].address} is unsendable — skipping`);
+                failedAddrs.push(pending[0].address);
+                setFailedRecipients([...failedAddrs]);
+                return;
             }
+
+            const mid = Math.ceil(pending.length / 2);
+            await processGroup(pending.slice(0, mid));
+            await processGroup(pending.slice(mid));
+        };
+
+        for (let ci = 0; ci < chunks.length; ci++) {
+            await processGroup(chunks[ci]);
         }
 
-        setFailedChunks(failed)
-        return { txHashes: transactions, failed }
+        setFailedRecipients(failedAddrs)
+        return { txHashes: transactions, failed: failedAddrs, error: lastError }
     }, [connectedAddress, payableRecords, checkpointKey, props.tokenAddress]);
 
     const payFee = useCallback(async () => {
@@ -343,6 +358,7 @@ const AirdropConfirmModal = (props: {
 
     const startAirdrop = useCallback(async () => {
         setError(null)
+        setFailedRecipients([])
         if (props.airdropDetails !== null && props.airdropDetails.length > 0) {
             setTxLoading(true)
 
@@ -356,11 +372,11 @@ const AirdropConfirmModal = (props: {
 
             console.log("airdrop")
             setProgress("Send airdrops")
-            const { txHashes, failed } = await sendAirdrops(props.tokenAddress, props.tokenDecimals)
+            const { txHashes, failed, error: sendError } = await sendAirdrops(props.tokenAddress, props.tokenDecimals)
             const partial = failed.length > 0
             setProgress(partial ? "" : "Done...")
             setTxLoading(false)
-            console.log(txHashes, "failed chunks:", failed)
+            console.log(txHashes, "failed recipients:", failed)
 
             // Who actually got paid (from the checkpoint's confirmed set) — so
             // logs and receipts reflect reality even on a partial run.
@@ -376,7 +392,7 @@ const AirdropConfirmModal = (props: {
                 )
                 : totalOut
             const partialNote = partial
-                ? ` [partial: ${paidRecipients.length}/${payable.length} recipients paid, ${failed.length} chunk(s) failed]`
+                ? ` [partial: ${paidRecipients.length}/${payable.length} recipients paid, ${failed.length} unsendable recipient(s) skipped]`
                 : ""
 
             // SHROOM launchpad tokens carry the raw subdenom as their on-chain
@@ -443,12 +459,20 @@ const AirdropConfirmModal = (props: {
             }
 
             if (partial) {
-                // Keep the checkpoint so the user can retry only the failed
-                // chunks; surface a clear, actionable message.
+                // After bisection these are individual addresses the chain
+                // refuses (blocked accounts, precompiles, real reverts) — retrying
+                // won't help, so show which ones and why instead of implying a
+                // retry will fix it. Progress is saved; the receipt lists them.
+                const reason: string =
+                    (sendError as any)?.originalMessage ||
+                    (sendError as any)?.message ||
+                    (typeof sendError === "string" ? sendError : "unknown error")
+                const sample = failed.slice(0, 3).join(", ") + (failed.length > 3 ? ` +${failed.length - 3} more` : "")
                 setError(
                     `Sent to ${paidRecipients.length}/${payable.length} recipients. ` +
-                    `${failed.length} transaction(s) failed. Your progress is saved — ` +
-                    `click "Retry failed" to send only the remaining recipients.`,
+                    `${failed.length} address(es) could not be paid and were skipped: ${sample}. ` +
+                    `These are addresses the chain refuses (e.g. module accounts) — retrying won't help. ` +
+                    `Last error: ${reason}. Download the receipt for the full list.`,
                 )
                 return
             }
@@ -474,12 +498,12 @@ const AirdropConfirmModal = (props: {
     }, [checkpointKey, payableRecords, props.tokenSymbol]);
 
     const hasProgress = paidCount > 0;
-    const remaining = Math.max(0, payable.length - paidCount);
-    const actionLabel = failedChunks.length > 0
-        ? `Retry failed (${remaining} left)`
-        : hasProgress
-            ? `Resume airdrop (${remaining} left)`
-            : "Do Airdrop";
+    // Known-unsendable recipients don't count as "remaining" — retrying them is
+    // futile, so the resume prompt shouldn't dangle a count that can never reach 0.
+    const remaining = Math.max(0, payable.length - paidCount - failedRecipients.length);
+    const actionLabel = hasProgress && remaining > 0
+        ? `Resume airdrop (${remaining} left)`
+        : "Do Airdrop";
 
     return (
         <>
@@ -526,6 +550,12 @@ const AirdropConfirmModal = (props: {
                                 {invalidAddressCount > 0 &&
                                     <div className="text-amber-400 text-xs mt-2">
                                         {invalidAddressCount} recipient{invalidAddressCount === 1 ? "" : "s"} with an invalid address will be skipped.
+                                    </div>
+                                }
+                                {blockedCount > 0 &&
+                                    <div className="text-amber-400 text-xs mt-2">
+                                        {blockedCount} bank-blocked address{blockedCount === 1 ? "" : "es"} (module accounts
+                                        like the exchange/auction module) excluded — the chain won't credit them.
                                     </div>
                                 }
 
@@ -597,8 +627,8 @@ const AirdropConfirmModal = (props: {
                                         <div>Completed tx: <b>{completedTx}</b> / {estimatedTx}</div>
                                     }
                                     {remaining > 0 && <div>Remaining: <b>{remaining}</b></div>}
-                                    {failedChunks.length > 0 &&
-                                        <div className="text-rose-400">Failed tx: <b>{failedChunks.length}</b></div>
+                                    {failedRecipients.length > 0 &&
+                                        <div className="text-rose-400">Skipped (unsendable): <b>{failedRecipients.length}</b></div>
                                     }
                                 </div>
                                 {hasProgress &&

--- a/src/views/Airdrop/blockedAddresses.ts
+++ b/src/views/Airdrop/blockedAddresses.ts
@@ -1,0 +1,40 @@
+// Bank-module *blocked* addresses on Injective mainnet — the x/auth module
+// accounts. The bank keeper refuses to credit any of these ("… is not allowed
+// to receive funds"), and that refusal fires during gas *simulation*, so a
+// MsgMultiSend / CW20-transfer batch that contains one of them reverts before
+// it's ever broadcast — silently stranding the other ~499 recipients in the
+// same chunk.
+//
+// These addresses are derived deterministically from the module name
+// (authtypes.NewModuleAddress) and never change, so hard-coding them is safe.
+// The airdrop send loop *also* bisects any chunk that still fails, so an
+// address missing from this list (a future module, an EVM precompile, …) only
+// ever strands itself — this list just spares the common case the extra txs.
+//
+// Source: GET /cosmos/auth/v1beta1/module_accounts (mainnet), 2026-07-09.
+export const BLOCKED_RECIPIENTS: ReadonlySet<string> = new Set([
+    "inj1j4yzhgjm00ch3h0p9kel7g8sp6g045qf32pzlj", // auction
+    "inj1fl48vsnmsdzcv85q5d2q4z5ajdha8yu3lj7tt0", // bonded_tokens_pool
+    "inj1jv65s3grqf6v6jl3dp4t6c9t9rk99cd8dkncm8", // distribution
+    "inj1glht96kr2rseywuvhhay894qw7ekuc4qqdy7m7", // erc20
+    "inj1vqu8rska6swzdmnhf90zuv0xmelej4lq8mjsxs", // evm
+    "inj14vnmw2wee3xtrsqfvpcqg35jg9v7j2vdpzx0kk", // exchange
+    "inj17xpfvakm2amg962yls6f84z3kell8c5l6s5ye9", // fee_collector
+    "inj176rcyfn5k9d0wcxel3kmwvxh0hy3xcwen9585u", // feeibc
+    "inj10d07y265gmmuvt4z0w9aw880jnsr700jstypyt", // gov
+    "inj1vn5fx74ud4cu7tf0pls9u5krxengsdzrg9ap2d", // insurance
+    "inj1vlthgax23ca9syk7xgaz347xmf4nunefdppn7g", // interchainaccounts
+    "inj1m3h30wlvsf8llruxtpukdvsy0km2kum8zcsu4c", // mint
+    "inj1tygms3xhhs3yv487phx3dw4a95jn7t7ltjz6am", // not_bonded_tokens_pool
+    "inj1979qcq0kdz72w0k9rsxcmfmagx2cydrs40q2xg", // peggy
+    "inj1fl3um4qyagpfpwked5lpenvjj7wn8trr93jdku", // permissions
+    "inj19ejy8n9qsectrf4semdp9cpknflld0j6hf2fle", // tokenfactory
+    "inj1yl6hdjhmkf37639730gffanpzndzdpmhykpd9m", // transfer
+    "inj1h3j5kq3efj96ga8gre6pxmp2qmfvs994clv2su", // txfees
+    "inj1xds4f0m87ajl3a6az6s2enhxrd0wta4860twp8", // wasm
+    "inj1z5ewmnfpa3at4j54pq6dh66rthrpkvhnxqadkf", // xwasm
+]);
+
+export function isBlockedRecipient(address: string): boolean {
+    return BLOCKED_RECIPIENTS.has((address || "").trim());
+}

--- a/src/views/Airdrop/distribution.ts
+++ b/src/views/Airdrop/distribution.ts
@@ -10,9 +10,43 @@ import type { AirdropRecipient, DistMode, VoteFilters } from "./types";
 // chain rounds each transfer to the token's decimals.
 export const DUST_HAIRCUT = 0.00001;
 
-// Recipients per transaction (MsgMultiSend outputs / CW20 transfer messages).
-// Shared with the confirm modal so the tx-count estimate matches execution.
-export const CHUNK_SIZE = 500;
+// Recipients per transaction. Sized from on-chain gas simulation (2026-07-09,
+// mainnet): a native/factory MsgMultiSend costs a dead-linear ~44,010 gas per
+// output, so with the 1.3x airdrop gas buffer, gasWanted ≈ 57,213 · n. Measured:
+//   n=1000 → 57.3M gasWanted (38% of the 150M block gas limit)  ← chosen default
+//   n=1500 → 85.9M (57%)     n=2000 → 114.5M (76%)     n=2500 → 143.2M (95%)
+//   n≥3000 → >150M: can never fit a block. Simulate itself also dies ~3,500.
+// Hard ceiling is ~2,600 outputs. 1000 halves the tx count (a 36k drop: 74 → 37)
+// while staying comfortably under any plausible node `max-tx-gas-wanted` mempool
+// cap (57M is a routine Injective tx size) so chunks land first-try. Push higher
+// (→1500/2000) only after confirming a run lands without bisecting — the send
+// loop bisects any rejected chunk, so an over-estimate is self-correcting but
+// wastes a retry round per chunk before it splits.
+export const NATIVE_CHUNK_SIZE = 1000;
+
+// CW20 transfers are one contract-execute *per recipient* (~3-4x the gas of a
+// bank output), so they need a much smaller batch. Left at the previously-shipped
+// value — CW20-token drops are rare (launchpad tokens are native factory denoms).
+export const CW20_CHUNK_SIZE = 500;
+
+// Back-compat default (native). Prefer chunkSizeForDenom() when the denom is known.
+export const CHUNK_SIZE = NATIVE_CHUNK_SIZE;
+
+// Native/bank denoms go out as a single MsgMultiSend; everything else (a CW20
+// contract address) goes out as one execute per recipient. Mirrors the check in
+// the confirm modal's send loop so the tx-count estimate matches execution.
+export function isNativeDenomSend(denom: string): boolean {
+    return (
+        denom.includes("factory") ||
+        denom.includes("peggy") ||
+        denom.includes("ibc") ||
+        denom === "inj"
+    );
+}
+
+export function chunkSizeForDenom(denom: string): number {
+    return isNativeDenomSend(denom) ? NATIVE_CHUNK_SIZE : CW20_CHUNK_SIZE;
+}
 
 export function netSupply(total: number): number {
     const n = Number(total) || 0;
@@ -168,6 +202,7 @@ export function summarize(
     recipients: AirdropRecipient[],
     total: number,
     decimals: number,
+    chunkSize: number = NATIVE_CHUNK_SIZE,
 ): AirdropSummary {
     const paid = recipients.filter(
         (r) => r.includeInDrop && Number(Number(r.amountToAirdrop).toFixed(decimals)) > 0,
@@ -180,6 +215,6 @@ export function summarize(
         recipientCount: paid.length,
         totalOut,
         reserved: Math.max(0, (Number(total) || 0) - totalOut),
-        txCount: Math.ceil(paid.length / CHUNK_SIZE),
+        txCount: Math.ceil(paid.length / chunkSize),
     };
 }


### PR DESCRIPTION
## Problem

The `partial: N/N+500 recipients paid, 1 chunk(s) failed` airdrop alerts (e.g. BERB → HDRO/Pedro holders, 2026-07-09). The math showed **exactly one full 500-recipient chunk** failing per run — and a *retry reproduced the identical failure*, so it's deterministic.

**Confirmed root cause:** a single **bank-blocked module account** is included as a "holder", and the bank keeper refuses to credit it (`… is not allowed to receive funds`). That refusal fires during **gas simulation**, so the whole `MsgMultiSend` chunk reverts *before it's ever broadcast* — it never appears on-chain, retries can't help, and all ~500 recipients in that chunk are stranded.

**Proof:** the `exchange` module `inj14vnmw2wee3xtrsqfvpcqg35jg9v7j2vdpzx0kk` (which holds every Helix depositor's aggregate balance) held **49.1M HDRO** and wrapped PEDRO but received **0 BERB** — targeted by both drops, credited by neither. The `auction` module (fee basket) holds both too. The tool's exclude list covered burn/adapter/LP/token addresses but **not** the x/auth module accounts.

## Fix

1. **Pre-filter blocked accounts** — new `blockedAddresses.ts` with the 20 mainnet x/auth module accounts (deterministic, permanent). `isPayable` drops them; a pre-flight note shows how many were excluded.
2. **Bisect-on-failure** — when a chunk fails all retries, split it in half recursively down to a single address, so any unsendable recipient (blocked / precompile / future) strands **only itself**, not its ~499 chunk-mates. Idempotent via the existing checkpoint. `failed` now reports unsendable *addresses* (not chunk indices), and the real revert reason is surfaced in the UI instead of console-only.
3. **Chunk resize from measured gas** — on-chain simulation (mainnet, real BERB denom + real addresses, validated to ±0.3% of actual) shows a native `MsgMultiSend` costs a **dead-linear ~44,010 gas/output**; the **150M block gas limit** caps a batch at **~2,600 outputs**. `NATIVE_CHUNK_SIZE` 500 → **1000** (57M gasWanted, 38% of a block — lands first-try, ~halves the tx count on large drops). CW20 stays 500 (one execute per recipient, ~3-4× gas); `chunkSizeForDenom()` picks per denom. Header comment documents the 1500/2000 headroom to push to later.

| chunk | gasUsed | gasWanted (1.3×) | % of block |
|------:|--------:|-----------------:|-----------:|
| 500 (old) | 22.1M | 28.7M | 19% |
| **1000 (new)** | 44.1M | 57.3M | 38% |
| 2500 | 110.1M | 143.2M | 95% |
| 3000 | 132.1M | 171.8M | >100% (impossible) |

## Verification
- `tsc --noEmit` clean, eslint clean, `npm run build` ✓
- Simulation reproduced the real 500-output gas within 0.3%.

⚠️ **This repo auto-deploys on merge.** Before merging, run one real drop and watch it complete — ideally on a Helix-listed token (whose holders include the exchange module) to confirm the pre-filter engages and the run finishes 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)