### PR TITLE
perf(swap): raise route finding to 4 hops

### DIFF
--- a/src/utils/swap/constants.ts
+++ b/src/utils/swap/constants.ts
@@ -22,9 +22,10 @@ export const USE_NEW_AGGREGATION_SHAPE = true;
 export const USE_V3_ROUTING = true;
 export const ROUTE_FIELD = USE_V3_ROUTING ? 'findOptimalRouteV3' : 'findOptimalRoute';
 
-// Max hops the backend route finder may chain. Choice derives this per-wallet;
-// 3 is the standard default and is plenty for the SHROOM ecosystem pairs.
-export const MAX_HOPS = 3;
+// Max hops the backend route finder may chain. 4 reaches tokens whose only
+// deep pool is quoted in a non-hub token (e.g. USDT>INJ>SHROOM>SAI>token for
+// SAI-quoted launchpad graduates); the v3 router handles depth 4 in ~1s.
+export const MAX_HOPS = 4;
 
 // Canonical mainnet quote-asset denoms.
 export const INJ = 'inj';


### PR DESCRIPTION
One-line follow-up to choice-exchange/choice_exchange_backend#277 (**already deployed**): the v3 router now handles depth-4 search in ~1s, and 4 hops is what reaches tokens whose only deep pool is quoted in a non-hub token. Buying a SAI-quoted launchpad graduate with USDT routes `USDT→INJ→SHROOM→SAI→token` — at `MAX_HOPS = 3` the swap was forced through a thin direct pool (+63% worse fill on the live USDT→BERB case).

The swap already uses `findOptimalRouteV3` unconditionally, so this is safe to ship now. `typecheck` passes.

⚠️ Note: master auto-deploys — merge when ready to ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)